### PR TITLE
docs(notebooks): add two-layer pattern walkthrough

### DIFF
--- a/notebooks/multitenant_schema_walkthrough.ipynb
+++ b/notebooks/multitenant_schema_walkthrough.ipynb
@@ -7,7 +7,12 @@
    "source": [
     "# From Prompt to Persistence: Multi-Tenant Memory Schema\n",
     "\n",
-    "Companion notebook for **From Prompt to Persistence: Designing Multi-Tenant Agent Memory Schemas for SaaS**. Every SQL query from the article runs here against a real Oracle AI Database instance, in the order the article presents them: schema DDL, RLS policy, session context, sample data, canonical retrieval predicate, supersession, right-to-forget cascade, and the unified retrieval query.\n",
+    "Companion notebook for the two-part *From Prompt to Persistence* series:\n",
+    "\n",
+    "- Part 1 — [Designing Multi-Tenant Agent Memory Schemas for SaaS](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-1-designing-multi-tenant-agent-memory-schemas-for-saas) designs the durable layer: eight typed memory tables that all carry the same scope columns, with tenant isolation enforced by row-level security rather than by convention.\n",
+    "- Part 2 — [Putting the Multi-Tenant Agent Memory Schema to Work](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-2-putting-the-multi-tenant-agent-memory-schema-to-work) puts that schema to work: the retrieval query the agent loop reads from, plus versioned supersession and a provable right-to-forget cascade.\n",
+    "\n",
+    "Every SQL statement from both articles runs here against a real Oracle AI Database instance, in the order the articles present them: schema DDL, RLS policy, session context, sample data, the canonical retrieval predicate, supersession, the right-to-forget cascade, and the unified retrieval query.\n",
     "\n",
     "## Prerequisites\n",
     "\n",
@@ -17,7 +22,7 @@
     "- ONNX embedding model loaded (`ALL_MINILM_L12_V2`, 384-dim); see the project README for the loader script\n",
     "- A `.env` file with `DB_USER`, `DB_PASSWORD`, `DB_DSN`\n",
     "\n",
-    "The article's DDL declares vectors as `VECTOR(1024, FLOAT32)` as an illustrative dimension. This notebook uses `VECTOR(384, FLOAT32)` to match `ALL_MINILM_L12_V2`. The shape of the SQL is identical; only the dimension number changes."
+    "Part 1's DDL declares vectors as `VECTOR(1024, FLOAT32)` as an illustrative dimension. This notebook uses `VECTOR(384, FLOAT32)` to match `ALL_MINILM_L12_V2`. The shape of the SQL is identical; only the dimension number changes."
    ]
   },
   {
@@ -541,7 +546,7 @@
    "source": [
     "### 2h. `knowledge_base_document` + `knowledge_base_chunk` (Semantic)\n",
     "\n",
-    "Note that `knowledge_base_document` stores a `source_uri` **pointer** to the original document (e.g. an object-storage path) plus metadata: title, collection, source type, and provenance. It does **not** store the document's content. The searchable text lives only in `knowledge_base_chunk.content`, chunked and embedded; the original bytes (the PDF, the HTML) stay in object storage, referenced by `source_uri`. The database holds the derived, retrievable form and a pointer home, not the raw file.\n"
+    "Note that `knowledge_base_document` stores a `source_uri` **pointer** to the original document (e.g. an object-storage path) plus metadata: title, collection, source type, and provenance. It does **not** store the document's content. The searchable text lives only in `knowledge_base_chunk.content`, chunked and embedded; the original bytes (the PDF, the HTML) stay in object storage, referenced by `source_uri`. The database holds the derived, retrievable form and a pointer home; the raw file never lands in a table."
    ]
   },
   {
@@ -674,7 +679,7 @@
    "source": [
     "## 3. Tenant isolation via row-level security\n",
     "\n",
-    "The function returns the predicate `tenant_id = SYS_CONTEXT('memory_ctx','tenant_id')` and the loop attaches it to all nine tenant-scoped data tables (the seven `*_MEMORY` tables plus the two `knowledge_base_*` tables) for SELECT, INSERT, UPDATE, and DELETE. `update_check => TRUE` is what makes the INSERT half real: a careless INSERT with the wrong `tenant_id` is blocked at the statement layer, not just filtered on read. A developer who forgets to filter by tenant can't write a leaking query because the database refuses to run one."
+    "The function returns the predicate `tenant_id = SYS_CONTEXT('memory_ctx','tenant_id')` and the loop attaches it to all nine tenant-scoped data tables (the seven `*_MEMORY` tables plus the two `knowledge_base_*` tables) for SELECT, INSERT, UPDATE, and DELETE. `update_check => TRUE` is what makes the INSERT half real: a careless INSERT with the wrong `tenant_id` is blocked at the statement layer instead of merely filtered out on read. A developer who forgets to filter by tenant can't write a leaking query because the database refuses to run one."
    ]
   },
   {
@@ -1102,7 +1107,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Inserted entity ent_96422feecdf8 (version 1).\n"
+      "Inserted entity ent_691e4ca03e04 (version 1).\n"
      ]
     }
    ],
@@ -1158,8 +1163,8 @@
      "output_type": "stream",
      "text": [
       "Supersession chain:\n",
-      "  v1 id=ent_96422feecdf8  valid_until=2026-05-29T16:53:39.232652  superseded_by=ent_8474242e5a0c\n",
-      "  v2 id=ent_8474242e5a0c  valid_until=<active>  superseded_by=None\n"
+      "  v1 id=ent_691e4ca03e04  valid_until=2026-07-08T12:24:15.459233  superseded_by=ent_9b2f2462724f\n",
+      "  v2 id=ent_9b2f2462724f  valid_until=<active>  superseded_by=None\n"
      ]
     }
    ],
@@ -1232,7 +1237,7 @@
      "output_type": "stream",
      "text": [
       "Active row(s) under default retrieval predicate:\n",
-      "  v2  id=ent_8474242e5a0c  Production database is in eu-west-1, replicas in eu-central-1. Migrated 2026-04.\n"
+      "  v2  id=ent_9b2f2462724f  Production database is in eu-west-1, replicas in eu-central-1. Migrated 2026-04.\n"
      ]
     }
    ],
@@ -1263,13 +1268,13 @@
     "\n",
     "Three retrieval styles coexist in one statement, matching how the Retrieve step describes each type:\n",
     "\n",
-    "- **Enumerated** (guideline, persona, toolbox): loaded in full with no score; a policy or tool that applies must apply.\n",
-    "- **Hybrid** (entity, summarization): a vector candidate pool and an Oracle Text `CONTAINS` pool, `FULL OUTER JOIN`ed so each row carries **both** a `vec_score` and a `lex_score`. We show the two signals side by side rather than fusing them into one number; fusion and reranking (`DBMS_VECTOR.RERANK`) are a separate, downstream topic.\n",
-    "- **Vector-only** (workflow, knowledge base): similarity match on the embedding.\n",
+    "- Enumerated types (guideline, persona, toolbox) load in full with no score; a policy or tool that applies must apply.\n",
+    "- Hybrid types (entity, summarization) build a vector candidate pool and an Oracle Text `CONTAINS` pool, `FULL OUTER JOIN`ed so each row carries **both** a `vec_score` and a `lex_score`. We show the two signals side by side rather than fusing them into one number; fusion and reranking (`DBMS_VECTOR.RERANK`) are a separate, downstream topic.\n",
+    "- Vector-only types (workflow, knowledge base) do a similarity match on the embedding.\n",
     "\n",
     "The `relevance` column maps the vector score to a tier the application can read directly: `high` ≥ 0.7, `standard` ≥ 0.5, `low` < 0.5. The `type` column tags every row so the application can route each one to the right part of the prompt (static prefix vs. ranked context).\n",
     "\n",
-    "Note the knowledge-base branch returns the matched **chunk** plus its document's `title`/`collection` for citation and a `document_id`/`chunk_index` handle, never the full document body. That keeps the prompt lean and leaves the chunk *addressable*: if the agent decides it needs more, it can fetch the parent document or neighboring chunks on demand rather than paying for them up front.\n"
+    "Note the knowledge-base branch returns the matched **chunk** plus its document's `title`/`collection` for citation and a `document_id`/`chunk_index` handle, never the full document body. That keeps the prompt lean and leaves the chunk *addressable*: if the agent decides it needs more, it can fetch the parent document or neighboring chunks on demand rather than paying for them up front."
    ]
   },
   {
@@ -1748,10 +1753,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "df23d90b3fa5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleanup complete.\n"
+     ]
+    }
+   ],
    "source": [
     "# Drop policies (best-effort).\n",
     "cur.execute(\"\"\"\n",

--- a/notebooks/two_layer_pattern_walkthrough.ipynb
+++ b/notebooks/two_layer_pattern_walkthrough.ipynb
@@ -1,0 +1,950 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "50deee74",
+   "metadata": {},
+   "source": [
+    "# Persistent Memory and Derived Context: A Two-Layer Pattern for Agents\n",
+    "\n",
+    "Companion notebook for the Oracle AI Database article *Persistent Memory and Derived Context: A Two-Layer Pattern for Agents*. It runs on the schema from the previous articles, From Prompt to Persistence [part 1](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-1-designing-multi-tenant-agent-memory-schemas-for-saas) and [part 2](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-2-putting-the-multi-tenant-agent-memory-schema-to-work), unchanged. Their companion notebook is [multitenant_schema_walkthrough.ipynb](https://github.com/oracle-devrel/oracle-ai-developer-hub/blob/8c9ed028b1bea545f2cbefe057470a0294bf29b7/notebooks/multitenant_schema_walkthrough.ipynb).\n",
+    "\n",
+    "The boundary in this article is logical. Persistent memory is what's true; derived context is that same knowledge shaped for fast retrieval. In a converged store the two share a row: `content` is canonical, the `embedding` column is derived from it. Provenance runs one way, from the embedding back to the content, and because they live in the same row, one ACID write keeps them together. There's no separate derived-layer table. The derived layer is a column.\n",
+    "\n",
+    "The notebook runs the whole pattern against a live database. It builds the schema, writes a fact and its embedding in one statement, then corrects them in one statement and measures that the vector still tracks the fact. It chunks a document into the knowledge-base tables and rebuilds those chunks from the source. And it walks the sync strategies that keep derived context in step with canonical.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- Oracle AI Database at `localhost:1521/FREEPDB1` (or set `DB_DSN`), with a non-zero `vector_memory_size`.\n",
+    "- A user with `DB_DEVELOPER_ROLE`, `CREATE SESSION`, `CREATE TABLE`, `CREATE MATERIALIZED VIEW`, `EXECUTE ON DBMS_RLS`.\n",
+    "- The ONNX model `ALL_MINILM_L12_V2` (384-dim) loaded.\n",
+    "- A `.env` with `DB_USER`, `DB_PASSWORD`, `DB_DSN`.\n",
+    "\n",
+    "Vectors are `VECTOR(384, FLOAT32)` to match `ALL_MINILM_L12_V2`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "008ae263",
+   "metadata": {},
+   "source": [
+    "## 1. Environment & connection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "666d2209",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Oracle version: 23.26.1.0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, hashlib, uuid\n",
+    "\n",
+    "import oracledb\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "# Return CLOB columns (content, summary, chunk text) as str, not LOB locators, so the\n",
+    "# SUBSTR previews below print as text.\n",
+    "oracledb.defaults.fetch_lobs = False\n",
+    "\n",
+    "DB_USER     = os.environ[\"DB_USER\"]\n",
+    "DB_PASSWORD = os.environ[\"DB_PASSWORD\"]\n",
+    "DB_DSN      = os.getenv(\"DB_DSN\", \"localhost:1521/FREEPDB1\")\n",
+    "\n",
+    "conn = oracledb.connect(user=DB_USER, password=DB_PASSWORD, dsn=DB_DSN)\n",
+    "cur = conn.cursor()\n",
+    "# Pin the session to UTC — valid_from/valid_until/created_at are plain TIMESTAMP written\n",
+    "# from SYSTIMESTAMP (DB tz = UTC); a different session tz would misjudge superseded rows.\n",
+    "cur.execute(\"ALTER SESSION SET TIME_ZONE = 'UTC'\")\n",
+    "\n",
+    "def new_id(prefix: str) -> str:\n",
+    "    return f\"{prefix}_{uuid.uuid4().hex[:12]}\"\n",
+    "\n",
+    "def sha256(text: str) -> str:\n",
+    "    return hashlib.sha256(text.encode(\"utf-8\")).hexdigest()\n",
+    "\n",
+    "print(\"Oracle version:\", conn.version)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "849ce827",
+   "metadata": {},
+   "source": [
+    "## 2. The schema: canonical content and derived embedding, same row\n",
+    "\n",
+    "We rebuild the part of the previous articles' schema this walkthrough uses: `entity_memory` and `summarization_memory`, the append-only `conversation_memory`, and the knowledge-base pair. Each semantically-retrieved type carries an inline `embedding VECTOR(384, FLOAT32)` next to its canonical text. `conversation_memory` is the exception on purpose. It's the high-volume event stream, so it carries no embedding at all. Its derived context gets built separately, in section 10."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9b153510",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropped MV + tables (if they existed).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    cur.execute(\"DROP MATERIALIZED VIEW active_fact_retrieval\")\n",
+    "except oracledb.DatabaseError:\n",
+    "    pass\n",
+    "\n",
+    "TABLES = [\"knowledge_base_chunk\", \"knowledge_base_document\",\n",
+    "          \"summarization_memory\", \"conversation_memory\", \"entity_memory\"]\n",
+    "for t in TABLES:\n",
+    "    try:\n",
+    "        cur.execute(f\"DROP TABLE {t} CASCADE CONSTRAINTS PURGE\")   # drops RLS policies with it\n",
+    "    except oracledb.DatabaseError:\n",
+    "        pass\n",
+    "print(\"Dropped MV + tables (if they existed).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6f66d569",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "entity_memory created (inline embedding + vector index).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# entity_memory — canonical fact + inline (derived) embedding on the same row.\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE TABLE entity_memory (\n",
+    "  id              VARCHAR2(64)  PRIMARY KEY,\n",
+    "  tenant_id       VARCHAR2(64)  NOT NULL,\n",
+    "  user_id         VARCHAR2(64),\n",
+    "  agent_id        VARCHAR2(64),\n",
+    "  thread_id       VARCHAR2(64),\n",
+    "  subject         VARCHAR2(256) NOT NULL,\n",
+    "  predicate       VARCHAR2(64)  NOT NULL,\n",
+    "  content         CLOB,                       -- canonical fact text\n",
+    "  content_hash    VARCHAR2(64)  NOT NULL,\n",
+    "  content_json    JSON,\n",
+    "  embedding       VECTOR(384, FLOAT32),       -- derived from content, same row\n",
+    "  confidence      NUMBER(3,2)   NOT NULL,\n",
+    "  written_by      VARCHAR2(64)  NOT NULL,\n",
+    "  source_event_id VARCHAR2(64)  NOT NULL,\n",
+    "  version         NUMBER(10)    NOT NULL,\n",
+    "  superseded_by   VARCHAR2(64),\n",
+    "  valid_from      TIMESTAMP     NOT NULL,\n",
+    "  valid_until     TIMESTAMP,\n",
+    "  created_at      TIMESTAMP     NOT NULL,\n",
+    "  deleted_at      TIMESTAMP\n",
+    ")\n",
+    "\"\"\")\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE INDEX idx_entity_scope_active\n",
+    "  ON entity_memory (tenant_id, user_id, agent_id, thread_id, deleted_at, valid_until)\n",
+    "\"\"\")\n",
+    "cur.execute(\"CREATE INDEX idx_entity_subject ON entity_memory (tenant_id, subject)\")\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE VECTOR INDEX idx_entity_embedding ON entity_memory (embedding)\n",
+    "  ORGANIZATION INMEMORY NEIGHBOR GRAPH DISTANCE COSINE WITH TARGET ACCURACY 95\n",
+    "\"\"\")\n",
+    "print(\"entity_memory created (inline embedding + vector index).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3d0805c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "summarization_memory created (inline embedding + vector index).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# summarization_memory — distilled episode + inline embedding.\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE TABLE summarization_memory (\n",
+    "  id              VARCHAR2(64)  PRIMARY KEY,\n",
+    "  tenant_id       VARCHAR2(64)  NOT NULL,\n",
+    "  user_id         VARCHAR2(64),\n",
+    "  agent_id        VARCHAR2(64),\n",
+    "  thread_id       VARCHAR2(64),\n",
+    "  task_type       VARCHAR2(64)  NOT NULL,\n",
+    "  title           VARCHAR2(256) NOT NULL,\n",
+    "  summary         CLOB,\n",
+    "  outcome         VARCHAR2(64),\n",
+    "  embedding       VECTOR(384, FLOAT32),       -- derived from summary, same row\n",
+    "  confidence      NUMBER(3,2)   NOT NULL,\n",
+    "  written_by      VARCHAR2(64)  NOT NULL,\n",
+    "  source_event_id VARCHAR2(64)  NOT NULL,\n",
+    "  version         NUMBER(10)    NOT NULL,\n",
+    "  superseded_by   VARCHAR2(64),\n",
+    "  valid_from      TIMESTAMP     NOT NULL,\n",
+    "  valid_until     TIMESTAMP,\n",
+    "  completed_at    TIMESTAMP     NOT NULL,\n",
+    "  created_at      TIMESTAMP     NOT NULL,\n",
+    "  deleted_at      TIMESTAMP\n",
+    ")\n",
+    "\"\"\")\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE VECTOR INDEX idx_summ_embedding ON summarization_memory (embedding)\n",
+    "  ORGANIZATION INMEMORY NEIGHBOR GRAPH DISTANCE COSINE WITH TARGET ACCURACY 95\n",
+    "\"\"\")\n",
+    "print(\"summarization_memory created (inline embedding + vector index).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1881dd9e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "conversation_memory + knowledge_base_document + knowledge_base_chunk created.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# conversation_memory — high-volume raw event stream, NO inline embedding by design.\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE TABLE conversation_memory (\n",
+    "  event_id    VARCHAR2(64)  PRIMARY KEY,\n",
+    "  tenant_id   VARCHAR2(64)  NOT NULL,\n",
+    "  user_id     VARCHAR2(64),\n",
+    "  thread_id   VARCHAR2(64),\n",
+    "  run_id      VARCHAR2(64),\n",
+    "  turn_index  NUMBER,\n",
+    "  event_type  VARCHAR2(32),\n",
+    "  role        VARCHAR2(32),\n",
+    "  payload     JSON,\n",
+    "  created_at  TIMESTAMP     NOT NULL\n",
+    ")\n",
+    "\"\"\")\n",
+    "\n",
+    "# knowledge_base_document — a POINTER (source_uri) + metadata; the bytes stay in object storage.\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE TABLE knowledge_base_document (\n",
+    "  id          VARCHAR2(64)   PRIMARY KEY,\n",
+    "  tenant_id   VARCHAR2(64)   NOT NULL,\n",
+    "  collection  VARCHAR2(128)  NOT NULL,\n",
+    "  title       VARCHAR2(512)  NOT NULL,\n",
+    "  source_uri  VARCHAR2(1024),\n",
+    "  source_type VARCHAR2(64)   NOT NULL,\n",
+    "  ingested_at TIMESTAMP      NOT NULL,\n",
+    "  ingested_by VARCHAR2(64)   NOT NULL,\n",
+    "  version     NUMBER(10)     NOT NULL,\n",
+    "  valid_from  TIMESTAMP      NOT NULL,\n",
+    "  valid_until TIMESTAMP,\n",
+    "  created_at  TIMESTAMP      NOT NULL,\n",
+    "  deleted_at  TIMESTAMP\n",
+    ")\n",
+    "\"\"\")\n",
+    "\n",
+    "# knowledge_base_chunk — derived chunks of a document, each with an inline embedding.\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE TABLE knowledge_base_chunk (\n",
+    "  id          VARCHAR2(64)  PRIMARY KEY,\n",
+    "  tenant_id   VARCHAR2(64)  NOT NULL,\n",
+    "  document_id VARCHAR2(64)  NOT NULL,\n",
+    "  chunk_index NUMBER(10)    NOT NULL,\n",
+    "  content     CLOB          NOT NULL,\n",
+    "  embedding   VECTOR(384, FLOAT32),\n",
+    "  created_at  TIMESTAMP     NOT NULL,\n",
+    "  deleted_at  TIMESTAMP,\n",
+    "  CONSTRAINT fk_kb_chunk_doc FOREIGN KEY (document_id) REFERENCES knowledge_base_document (id)\n",
+    ")\n",
+    "\"\"\")\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE UNIQUE INDEX idx_kb_chunk_doc_idx\n",
+    "  ON knowledge_base_chunk (tenant_id, document_id, chunk_index)\n",
+    "\"\"\")\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE VECTOR INDEX idx_kb_chunk_embedding ON knowledge_base_chunk (embedding)\n",
+    "  ORGANIZATION INMEMORY NEIGHBOR GRAPH DISTANCE COSINE WITH TARGET ACCURACY 95\n",
+    "\"\"\")\n",
+    "print(\"conversation_memory + knowledge_base_document + knowledge_base_chunk created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74fe0b71",
+   "metadata": {},
+   "source": [
+    "## 3. Tenant isolation and session context\n",
+    "\n",
+    "Row-level security carries over from the previous articles, unchanged. One policy function returns `tenant_id = SYS_CONTEXT('memory_ctx','tenant_id')`, attached to every tenant-scoped table. `update_check => TRUE` stops a session from writing rows for another tenant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0c13b4af",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  CONVERSATION_MEMORY      <- CONVERSATION_MEMORY_TENANT_POL\n",
+      "  ENTITY_MEMORY            <- ENTITY_MEMORY_TENANT_POL\n",
+      "  KNOWLEDGE_BASE_CHUNK     <- KNOWLEDGE_BASE_CHUNK_TENANT_POL\n",
+      "  KNOWLEDGE_BASE_DOCUMENT  <- KNOWLEDGE_BASE_DOCUMENT_TENANT_POL\n",
+      "  SUMMARIZATION_MEMORY     <- SUMMARIZATION_MEMORY_TENANT_POL\n"
+     ]
+    }
+   ],
+   "source": [
+    "cur.execute(\"\"\"\n",
+    "CREATE OR REPLACE FUNCTION memory_tenant_policy(\n",
+    "  schema_in IN VARCHAR2, table_in IN VARCHAR2\n",
+    ") RETURN VARCHAR2 AS\n",
+    "BEGIN\n",
+    "  RETURN q'[\n",
+    "    tenant_id = SYS_CONTEXT('memory_ctx','tenant_id')\n",
+    "  ]';\n",
+    "END;\n",
+    "\"\"\")\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "BEGIN\n",
+    "  FOR rec IN (SELECT table_name FROM user_tables\n",
+    "               WHERE table_name LIKE '%_MEMORY'\n",
+    "                  OR table_name LIKE 'KNOWLEDGE_BASE%')\n",
+    "  LOOP\n",
+    "    BEGIN\n",
+    "      DBMS_RLS.ADD_POLICY(\n",
+    "        object_schema   => USER,\n",
+    "        object_name     => rec.table_name,\n",
+    "        policy_name     => rec.table_name || '_tenant_pol',\n",
+    "        policy_function => 'memory_tenant_policy',\n",
+    "        statement_types => 'SELECT,INSERT,UPDATE,DELETE',\n",
+    "        update_check    => TRUE);\n",
+    "    EXCEPTION WHEN OTHERS THEN\n",
+    "      IF SQLCODE = -28101 THEN NULL;   -- already exists; idempotent\n",
+    "      ELSE RAISE;\n",
+    "      END IF;\n",
+    "    END;\n",
+    "  END LOOP;\n",
+    "END;\n",
+    "\"\"\")\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "SELECT object_name, policy_name FROM user_policies\n",
+    " WHERE object_name LIKE '%_MEMORY' OR object_name LIKE 'KNOWLEDGE_BASE%'\n",
+    " ORDER BY object_name\n",
+    "\"\"\")\n",
+    "for row in cur:\n",
+    "    print(f\"  {row[0]:<24} <- {row[1]}\")\n",
+    "conn.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0d662457",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Active tenant: acme\n"
+     ]
+    }
+   ],
+   "source": [
+    "cur.execute(\"\"\"\n",
+    "CREATE OR REPLACE PACKAGE set_memory_ctx AS\n",
+    "  PROCEDURE set_tenant(p_tenant_id IN VARCHAR2);\n",
+    "END;\n",
+    "\"\"\")\n",
+    "cur.execute(\"\"\"\n",
+    "CREATE OR REPLACE PACKAGE BODY set_memory_ctx AS\n",
+    "  PROCEDURE set_tenant(p_tenant_id IN VARCHAR2) IS\n",
+    "  BEGIN\n",
+    "    DBMS_SESSION.SET_CONTEXT('memory_ctx', 'tenant_id', p_tenant_id);\n",
+    "  END;\n",
+    "END;\n",
+    "\"\"\")\n",
+    "cur.execute(\"CREATE OR REPLACE CONTEXT memory_ctx USING set_memory_ctx\")\n",
+    "\n",
+    "TENANT_ACME = \"acme\"\n",
+    "USER_ID     = \"user:jane@acme.com\"\n",
+    "\n",
+    "cur.callproc(\"set_memory_ctx.set_tenant\", [TENANT_ACME])\n",
+    "cur.execute(\"SELECT SYS_CONTEXT('memory_ctx','tenant_id') FROM dual\")\n",
+    "print(\"Active tenant:\", cur.fetchone()[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5084eea4",
+   "metadata": {},
+   "source": [
+    "## 4. Content is canonical, embedding is derived, one row and one write\n",
+    "\n",
+    "The article opens with a benchmark fact: Helios-RAG scores 0.92 nDCG@10 on BEIR. We seed it as an `entity_memory` row at version 1. The `content` is the canonical fact; the `embedding` is computed from that content by the database in the same `INSERT`. They enter together. We also seed the source conversation event and the paper's `knowledge_base_document` row, which the fact cites through `content_json`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6b03fe31",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Seeded fact v1: 'Helios-RAG achieves 0.92 nDCG@10 on the BEIR benchma'  | inline embedding present: yes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The paper the fact came from (a pointer + metadata; the PDF stays in object storage).\n",
+    "kb_doc_id = new_id(\"kbd\")\n",
+    "cur.execute(\"\"\"\n",
+    "INSERT INTO knowledge_base_document (id, tenant_id, collection, title, source_uri, source_type,\n",
+    "                                     ingested_at, ingested_by, version, valid_from, created_at)\n",
+    "VALUES (:id, :t, 'benchmarks',\n",
+    "        'Helios-RAG: A Retrieval-Augmented Model for Open-Domain QA (with erratum)',\n",
+    "        's3://acme-kb/papers/helios-rag.pdf', 'pdf', SYSTIMESTAMP, 'admin:acme', 1,\n",
+    "        SYSTIMESTAMP, SYSTIMESTAMP)\n",
+    "\"\"\", id=kb_doc_id, t=TENANT_ACME)\n",
+    "\n",
+    "# The source event that asserted the fact.\n",
+    "ev1 = new_id(\"evt\")\n",
+    "cur.execute(\"\"\"\n",
+    "INSERT INTO conversation_memory (event_id, tenant_id, user_id, thread_id, run_id,\n",
+    "                                 turn_index, event_type, role, payload, created_at)\n",
+    "VALUES (:e, :t, :u, 'thread_demo', 'run_demo', 1, 'model_msg', 'assistant',\n",
+    "        JSON('{ \"text\": \"Helios-RAG scores 0.92 nDCG@10 on BEIR.\" }'), SYSTIMESTAMP)\n",
+    "\"\"\", e=ev1, t=TENANT_ACME, u=USER_ID)\n",
+    "\n",
+    "# The canonical fact + its inline embedding, in one statement.\n",
+    "ent_v1 = new_id(\"ent\")\n",
+    "content_v1 = \"Helios-RAG achieves 0.92 nDCG@10 on the BEIR benchmark.\"\n",
+    "cur.execute(\"\"\"\n",
+    "INSERT INTO entity_memory (\n",
+    "  id, tenant_id, user_id, subject, predicate, content, content_hash, content_json,\n",
+    "  embedding, confidence, written_by, source_event_id, version, valid_from, created_at\n",
+    ") VALUES (\n",
+    "  :id, :t, :u, 'model:helios-rag', 'beir_ndcg10', :c, :h,\n",
+    "  JSON('{ \"entity_type\": \"benchmark_result\", \"source_document_id\": \"' || :doc || '\" }'),\n",
+    "  VECTOR_EMBEDDING(ALL_MINILM_L12_V2 USING :c2 AS DATA),\n",
+    "  0.95, 'agent:research_v1', :ev, 1, SYSTIMESTAMP, SYSTIMESTAMP\n",
+    ")\n",
+    "\"\"\", id=ent_v1, t=TENANT_ACME, u=USER_ID, c=content_v1, h=sha256(content_v1),\n",
+    "     doc=kb_doc_id, c2=content_v1, ev=ev1)\n",
+    "conn.commit()\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "SELECT version, SUBSTR(content,1,52) AS content,\n",
+    "       CASE WHEN embedding IS NULL THEN 'no' ELSE 'yes' END AS has_embedding\n",
+    "  FROM entity_memory WHERE id = :id\n",
+    "\"\"\", id=ent_v1)\n",
+    "r = cur.fetchone()\n",
+    "print(f\"Seeded fact v{r[0]}: {r[1]!r}  | inline embedding present: {r[2]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7efbe7cf",
+   "metadata": {},
+   "source": [
+    "## 5. The transactional supersede\n",
+    "\n",
+    "Six weeks on, the score is corrected to 0.78. In a polyglot stack the fact lives in one store and its vector in another, so a correction is two writes that can diverge, and the gap between them is where the opening scenario's drift comes from. In a converged store it's one statement. The `INSERT` carries the unchanged columns forward from the old row and recomputes the embedding from the corrected text. When the commit returns, no version of reality has the fact at 0.78 while its embedding still says 0.92. They're the same row, and ACID moved them together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6ff18e29",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Supersession chain (content + inline embedding moved together):\n",
+      "  v1  'Helios-RAG achieves 0.92 nDCG@10 on the BEIR benchmark'  retired\n",
+      "  v2  'Helios-RAG achieves 0.78 nDCG@10 on the BEIR benchmark'  <active>\n"
+     ]
+    }
+   ],
+   "source": [
+    "corr_ev = new_id(\"evt\")\n",
+    "cur.execute(\"\"\"\n",
+    "INSERT INTO conversation_memory (event_id, tenant_id, user_id, thread_id, run_id,\n",
+    "                                 turn_index, event_type, role, payload, created_at)\n",
+    "VALUES (:e, :t, :u, 'thread_demo', 'run_demo', 2, 'model_msg', 'assistant',\n",
+    "        JSON('{ \"text\": \"Correction: Helios-RAG BEIR score revised to 0.78.\" }'), SYSTIMESTAMP)\n",
+    "\"\"\", e=corr_ev, t=TENANT_ACME, u=USER_ID)\n",
+    "\n",
+    "ent_v2 = new_id(\"ent\")\n",
+    "content_v2 = \"Helios-RAG achieves 0.78 nDCG@10 on the BEIR benchmark (corrected).\"\n",
+    "cur.execute(\"\"\"\n",
+    "INSERT INTO entity_memory (\n",
+    "  id, tenant_id, user_id, agent_id, thread_id, subject, predicate, content, content_hash,\n",
+    "  content_json, embedding, confidence, written_by, source_event_id, version, valid_from, created_at\n",
+    ")\n",
+    "SELECT :new_id, tenant_id, user_id, agent_id, thread_id, subject, predicate,\n",
+    "       :c, :h, content_json,\n",
+    "       VECTOR_EMBEDDING(ALL_MINILM_L12_V2 USING :c2 AS DATA),\n",
+    "       confidence, written_by, :ev, version + 1, SYSTIMESTAMP, SYSTIMESTAMP\n",
+    "FROM   entity_memory WHERE id = :old_id\n",
+    "\"\"\", new_id=ent_v2, c=content_v2, h=sha256(content_v2), c2=content_v2, ev=corr_ev, old_id=ent_v1)\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "UPDATE entity_memory SET valid_until = SYSTIMESTAMP, superseded_by = :new_id\n",
+    " WHERE id = :old_id AND valid_until IS NULL\n",
+    "\"\"\", new_id=ent_v2, old_id=ent_v1)\n",
+    "conn.commit()\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "SELECT version, SUBSTR(content,1,54) AS content, valid_until\n",
+    "  FROM entity_memory\n",
+    " WHERE subject = 'model:helios-rag' AND predicate = 'beir_ndcg10'\n",
+    " ORDER BY version\n",
+    "\"\"\")\n",
+    "print(\"Supersession chain (content + inline embedding moved together):\")\n",
+    "for r in cur:\n",
+    "    print(f\"  v{r[0]}  {r[1]!r}  {'<active>' if r[2] is None else 'retired'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca036899",
+   "metadata": {},
+   "source": [
+    "## 6. No drift, by construction\n",
+    "\n",
+    "The embedding was recomputed from the corrected content in the same write, so the in-force row's embedding reflects the corrected 0.78. We can measure it. The cosine distance between the stored embedding and a fresh embedding of the current content is about zero, while the distance to a fresh embedding of the old content is larger. The vector tracks the fact. No stale-embedding path is left to retrieve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "49352819",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "stored embedding vs CURRENT content (0.78): distance = 0.000000  (~0 -> tracks the fact)\n",
+      "stored embedding vs OLD content     (0.92): distance = 0.016073  (larger -> not the stale vector)\n",
+      "no drift: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "cur.execute(\"\"\"\n",
+    "SELECT VECTOR_DISTANCE(embedding, VECTOR_EMBEDDING(ALL_MINILM_L12_V2 USING :cur AS DATA), COSINE) AS d_current,\n",
+    "       VECTOR_DISTANCE(embedding, VECTOR_EMBEDDING(ALL_MINILM_L12_V2 USING :old AS DATA), COSINE) AS d_old\n",
+    "  FROM entity_memory\n",
+    " WHERE subject = 'model:helios-rag' AND predicate = 'beir_ndcg10'\n",
+    "   AND valid_until IS NULL AND deleted_at IS NULL\n",
+    "\"\"\", cur=content_v2, old=content_v1)\n",
+    "d_current, d_old = cur.fetchone()\n",
+    "print(f\"stored embedding vs CURRENT content (0.78): distance = {d_current:.6f}  (~0 -> tracks the fact)\")\n",
+    "print(f\"stored embedding vs OLD content     (0.92): distance = {d_old:.6f}  (larger -> not the stale vector)\")\n",
+    "print(\"no drift:\", d_current < d_old)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e72650c",
+   "metadata": {},
+   "source": [
+    "## 7. Summaries carry an inline embedding\n",
+    "\n",
+    "`summarization_memory` carries an inline embedding like the other semantic types, so a finished summary is written with its vector in one statement. What sets summaries apart is the sync strategy after that. A summary is an episodic snapshot of completed work, so when the source it was distilled from moves on, you rebuild the summary on a schedule, and sometimes you leave it pinned on purpose. Here we write one finished summary with its embedding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "81b329ac",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Summary inserted inline: 'Helios-RAG evaluation for compliance corpus'  outcome='recommend_against'  embedding present: yes\n"
+     ]
+    }
+   ],
+   "source": [
+    "sum_id = new_id(\"sum\")\n",
+    "summary = (\"Evaluated Helios-RAG for the customer's retrieval stack. On BEIR it lands at \"\n",
+    "           \"0.78 nDCG@10 after the contamination correction, below the 0.85 bar the customer \"\n",
+    "           \"set, so we recommended against adopting it for the compliance corpus.\")\n",
+    "cur.execute(\"\"\"\n",
+    "INSERT INTO summarization_memory (\n",
+    "  id, tenant_id, user_id, task_type, title, summary, outcome,\n",
+    "  embedding, confidence, written_by, source_event_id, version, valid_from, completed_at, created_at\n",
+    ") VALUES (\n",
+    "  :id, :t, :u, 'model_eval', 'Helios-RAG evaluation for compliance corpus', :s, 'recommend_against',\n",
+    "  VECTOR_EMBEDDING(ALL_MINILM_L12_V2 USING :s2 AS DATA),\n",
+    "  0.9, 'agent:research_v1', :ev, 1, SYSTIMESTAMP, SYSTIMESTAMP, SYSTIMESTAMP\n",
+    ")\n",
+    "\"\"\", id=sum_id, t=TENANT_ACME, u=USER_ID, s=summary, s2=summary, ev=corr_ev)\n",
+    "conn.commit()\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "SELECT title, outcome, CASE WHEN embedding IS NULL THEN 'no' ELSE 'yes' END\n",
+    "  FROM summarization_memory WHERE id = :id\n",
+    "\"\"\", id=sum_id)\n",
+    "r = cur.fetchone()\n",
+    "print(f\"Summary inserted inline: {r[0]!r}  outcome={r[1]!r}  embedding present: {r[2]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3baddf78",
+   "metadata": {},
+   "source": [
+    "## 8. Chunking is a knowledge-base operation\n",
+    "\n",
+    "Chunking splits a document into passages and embeds each one, and the schema has two tables for it: `knowledge_base_document`, the pointer, and `knowledge_base_chunk`, the chunked text plus an inline embedding per chunk. That's where `DBMS_VECTOR_CHAIN` earns its place, and it's the table the article's rebuild query writes to. Two details make that query run. `UTL_TO_CHUNKS` returns a collection of JSON documents, so the chunk text is `JSON_VALUE(ct.column_value, '$.chunk_data')`. And each chunk needs its own key, so we generate a per-row `SYS_GUID()` and number the chunks with `ROW_NUMBER()`. The canonical source is the document in object storage, referenced by `source_uri`; here `doc_text` stands in for its fetched text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d7f4962a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ingested 2 chunks (each with an inline embedding):\n",
+      "  [1] 'Helios-RAG is a retrieval-augmented model for open-domain '\n",
+      "  [2] 'passages and re-running the evaluation, the corrected scor'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Stand-in for the document's fetched text (in production, read from source_uri).\n",
+    "doc_text = (\n",
+    "  \"Helios-RAG is a retrieval-augmented model for open-domain question answering. \"\n",
+    "  \"The original paper reported 0.92 nDCG@10 on the BEIR benchmark, averaged across its 14 \"\n",
+    "  \"retrieval tasks. A later erratum traced that figure to a data-contamination bug: several \"\n",
+    "  \"BEIR test passages had leaked into the training corpus, inflating retrieval scores. After \"\n",
+    "  \"removing the leaked passages and re-running the evaluation, the corrected score is 0.78 \"\n",
+    "  \"nDCG@10. The authors attribute the gap primarily to the MS MARCO and HotpotQA splits, \"\n",
+    "  \"where contamination was heaviest. The architecture and training recipe are unchanged; \"\n",
+    "  \"only the benchmark number was revised.\"\n",
+    ")\n",
+    "\n",
+    "# Chunk-and-embed pipeline: chunk the source, embed each chunk, land in knowledge_base_chunk.\n",
+    "INGEST_CHUNKS = \"\"\"\n",
+    "INSERT INTO knowledge_base_chunk (id, tenant_id, document_id, chunk_index, content, embedding, created_at)\n",
+    "WITH chunks AS (\n",
+    "  SELECT JSON_VALUE(ct.column_value, '$.chunk_data')                AS chunk_data,\n",
+    "         JSON_VALUE(ct.column_value, '$.chunk_id' RETURNING NUMBER) AS chunk_id\n",
+    "  FROM   TABLE(DBMS_VECTOR_CHAIN.UTL_TO_CHUNKS(:doc_text, JSON(:params))) ct\n",
+    ")\n",
+    "SELECT 'kbc_' || LOWER(RAWTOHEX(SYS_GUID())),        -- unique id per chunk\n",
+    "       :tenant_id, :doc_id,\n",
+    "       ROW_NUMBER() OVER (ORDER BY chunk_id),        -- chunk_index 1..N\n",
+    "       chunk_data,\n",
+    "       VECTOR_EMBEDDING(ALL_MINILM_L12_V2 USING chunk_data AS DATA),\n",
+    "       SYS_EXTRACT_UTC(SYSTIMESTAMP)\n",
+    "FROM chunks\n",
+    "\"\"\"\n",
+    "cur.execute(INGEST_CHUNKS, doc_text=doc_text,\n",
+    "            params='{\"by\":\"words\",\"max\":80,\"overlap\":10}', tenant_id=TENANT_ACME, doc_id=kb_doc_id)\n",
+    "conn.commit()\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "SELECT chunk_index, SUBSTR(content,1,58) FROM knowledge_base_chunk\n",
+    " WHERE document_id = :d ORDER BY chunk_index\n",
+    "\"\"\", d=kb_doc_id)\n",
+    "rows = cur.fetchall()\n",
+    "print(f\"Ingested {len(rows)} chunks (each with an inline embedding):\")\n",
+    "for r in rows:\n",
+    "    print(f\"  [{r[0]}] {r[1]!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf5e2881",
+   "metadata": {},
+   "source": [
+    "## 9. The rebuild path is the test\n",
+    "\n",
+    "The question that separates two layers from two tables: can you delete the whole derived layer and rebuild it from canonical alone? For the knowledge base, the derived layer is the chunks and their embeddings, and the canonical source is the document. Delete the chunks and re-ingest from the source, changing the chunk strategy while you're at it, because a new chunk size or a new embedding model is the same operation. The `knowledge_base_document` row never moves."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3205b9c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted the derived chunks (2 rows).\n",
+      "Rebuilt with finer chunks (max=80 -> 2 chunks; max=40 -> 4 chunks).\n",
+      "Canonical document unchanged: 'Helios-RAG: A Retrieval-Augmented Model for Open-Domain QA (with erratum)' (v1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "cur.execute(\"SELECT COUNT(*) FROM knowledge_base_chunk WHERE document_id = :d\", d=kb_doc_id)\n",
+    "before = cur.fetchone()[0]\n",
+    "\n",
+    "cur.execute(\"DELETE FROM knowledge_base_chunk WHERE document_id = :d\", d=kb_doc_id)\n",
+    "print(f\"Deleted the derived chunks ({before} rows).\")\n",
+    "\n",
+    "# Rebuild from canonical, with a finer chunk strategy.\n",
+    "cur.execute(INGEST_CHUNKS, doc_text=doc_text,\n",
+    "            params='{\"by\":\"words\",\"max\":40,\"overlap\":8}', tenant_id=TENANT_ACME, doc_id=kb_doc_id)\n",
+    "conn.commit()\n",
+    "\n",
+    "cur.execute(\"SELECT COUNT(*) FROM knowledge_base_chunk WHERE document_id = :d\", d=kb_doc_id)\n",
+    "after = cur.fetchone()[0]\n",
+    "cur.execute(\"SELECT title, version FROM knowledge_base_document WHERE id = :d\", d=kb_doc_id)\n",
+    "doc = cur.fetchone()\n",
+    "print(f\"Rebuilt with finer chunks (max=80 -> {before} chunks; max=40 -> {after} chunks).\")\n",
+    "print(f\"Canonical document unchanged: {doc[0]!r} (v{doc[1]}).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6426a6e4",
+   "metadata": {},
+   "source": [
+    "## 10. Three ways to keep the two layers in sync\n",
+    "\n",
+    "Once derived context can drift from canonical, the question is how fast you close the gap. You pick a strategy per memory type, weighing how costly a stale read is against how often the canonical data changes. A transactional rebuild happens in the same write, which is what an entity fact needs when a corrected number has to be right immediately. A scheduled refresh runs on a cadence, and it suits pre-joined materialized views and episodic summaries that tolerate an hour of lag. Lazy leaves the work until a read misses, which is all a high-volume conversation rollup requires. A converged store makes the transactional write cheap, since the embedding is computed in the same database in the same transaction, so you reserve the other two for the cases where cost is the constraint.\n",
+    "\n",
+    "### 10a. Scheduled: a materialized view\n",
+    "\n",
+    "`active_fact_retrieval` pre-joins in-force facts to their source documents and refreshes hourly. The `REFRESH ... NEXT ... INTERVAL '1' HOUR` clause is the scheduled strategy, written in DDL.\n",
+    "\n",
+    "> A materialized view can't be built over an RLS-protected table: its background refresh has no tenant context, so Oracle raises **ORA-30372**. An MV is a deployment-level projection, so we build it outside the tenant predicate. Detach the base-table policies, create the view, reattach them. In production you'd scope the projection per tenant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "fac7f93d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Article DDL under RLS -> ORA-30372: fine grain access policy conflicts with materialized view\n",
+      "\n",
+      "active_fact_retrieval (scheduled derived projection):\n",
+      "  model:helios-rag/beir_ndcg10  'Helios-RAG achieves 0.78 nDCG@10 on the '  <- 'Helios-RAG: A Retrieval-Augmented Model for Open-Domain QA (with erratum)'\n"
+     ]
+    }
+   ],
+   "source": [
+    "MV_DDL = \"\"\"\n",
+    "CREATE MATERIALIZED VIEW active_fact_retrieval\n",
+    "  REFRESH COMPLETE\n",
+    "  START WITH SYS_EXTRACT_UTC(SYSTIMESTAMP)\n",
+    "  NEXT SYS_EXTRACT_UTC(SYSTIMESTAMP) + INTERVAL '1' HOUR\n",
+    "AS\n",
+    "SELECT e.id, e.tenant_id, e.subject, e.predicate, e.content, e.embedding,\n",
+    "       d.title, d.source_uri\n",
+    "FROM   entity_memory e\n",
+    "LEFT   JOIN knowledge_base_document d\n",
+    "  ON   d.id = JSON_VALUE(e.content_json, '$.source_document_id')\n",
+    "WHERE  e.valid_until IS NULL\n",
+    "  AND  e.deleted_at  IS NULL\n",
+    "\"\"\"\n",
+    "\n",
+    "# The article's DDL, as written, over the RLS-protected base tables.\n",
+    "try:\n",
+    "    cur.execute(MV_DDL)\n",
+    "    print(\"Created (no policy on the base tables).\")\n",
+    "except oracledb.DatabaseError as e:\n",
+    "    print(\"Article DDL under RLS ->\", str(e).splitlines()[0])\n",
+    "\n",
+    "# Build outside the tenant predicate: detach base policies, create, reattach.\n",
+    "def _drop_pol(tbl):\n",
+    "    cur.execute(f\"\"\"BEGIN DBMS_RLS.DROP_POLICY(USER, '{tbl}', '{tbl}_tenant_pol');\n",
+    "                    EXCEPTION WHEN OTHERS THEN NULL; END;\"\"\")\n",
+    "def _add_pol(tbl):\n",
+    "    cur.execute(f\"\"\"BEGIN DBMS_RLS.ADD_POLICY(object_schema=>USER, object_name=>'{tbl}',\n",
+    "                    policy_name=>'{tbl}_tenant_pol', policy_function=>'memory_tenant_policy',\n",
+    "                    statement_types=>'SELECT,INSERT,UPDATE,DELETE', update_check=>TRUE);\n",
+    "                    EXCEPTION WHEN OTHERS THEN IF SQLCODE=-28101 THEN NULL; ELSE RAISE; END IF; END;\"\"\")\n",
+    "\n",
+    "for tbl in (\"ENTITY_MEMORY\", \"KNOWLEDGE_BASE_DOCUMENT\"):\n",
+    "    _drop_pol(tbl)\n",
+    "cur.execute(MV_DDL)\n",
+    "for tbl in (\"ENTITY_MEMORY\", \"KNOWLEDGE_BASE_DOCUMENT\"):\n",
+    "    _add_pol(tbl)\n",
+    "conn.commit()\n",
+    "\n",
+    "cur.execute(\"SELECT subject, predicate, SUBSTR(content,1,40), title FROM active_fact_retrieval\")\n",
+    "print(\"\\nactive_fact_retrieval (scheduled derived projection):\")\n",
+    "for r in cur:\n",
+    "    print(f\"  {r[0]}/{r[1]}  {r[2]!r}  <- {r[3]!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17c67601",
+   "metadata": {},
+   "source": [
+    "### 10b. Lazy: conversation rollups\n",
+    "\n",
+    "`conversation_memory` carries no inline embedding on purpose. It's the high-volume event stream, and embedding every logged turn would be wasteful. Its derived context, a semantic rollup over recent turns, is computed asynchronously and rebuilt on a read miss. The staleness that creates is bounded and intentional, a spend decision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d9e28259",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "conversation_memory: 2 event(s), inline embedding column present: no\n",
+      "Its derived rollup is built lazily/asynchronously into a separate structure (illustrative):\n",
+      "  CREATE TABLE conversation_rollup (... embedding VECTOR(384, FLOAT32) ...);\n",
+      "  -- populated on read miss over recent turns, not on every event insert\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The raw stream exists and is queryable; it just has no derived vector on the row.\n",
+    "cur.execute(\"SELECT COUNT(*) FROM conversation_memory\")\n",
+    "n = cur.fetchone()[0]\n",
+    "cur.execute(\"\"\"\n",
+    "SELECT COUNT(*) FROM user_tab_columns\n",
+    " WHERE table_name = 'CONVERSATION_MEMORY' AND column_name = 'EMBEDDING'\n",
+    "\"\"\")\n",
+    "has_vec = cur.fetchone()[0]\n",
+    "print(f\"conversation_memory: {n} event(s), inline embedding column present: {'yes' if has_vec else 'no'}\")\n",
+    "print(\"Its derived rollup is built lazily/asynchronously into a separate structure (illustrative):\")\n",
+    "print(\"  CREATE TABLE conversation_rollup (... embedding VECTOR(384, FLOAT32) ...);\")\n",
+    "print(\"  -- populated on read miss over recent turns, not on every event insert\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "491f6de3",
+   "metadata": {},
+   "source": [
+    "## 11. Cleanup\n",
+    "\n",
+    "Drop everything this notebook created: the materialized view, the policies, the tables, and the helper objects. Skip this cell to keep the seeded data around."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f8c62d64",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleanup complete.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    cur.execute(\"DROP MATERIALIZED VIEW active_fact_retrieval\")\n",
+    "except oracledb.DatabaseError:\n",
+    "    pass\n",
+    "\n",
+    "cur.execute(\"\"\"\n",
+    "BEGIN\n",
+    "  FOR rec IN (SELECT object_name, policy_name FROM user_policies\n",
+    "               WHERE object_name LIKE '%_MEMORY' OR object_name LIKE 'KNOWLEDGE_BASE%')\n",
+    "  LOOP\n",
+    "    BEGIN\n",
+    "      DBMS_RLS.DROP_POLICY(USER, rec.object_name, rec.policy_name);\n",
+    "    EXCEPTION WHEN OTHERS THEN NULL;\n",
+    "    END;\n",
+    "  END LOOP;\n",
+    "END;\n",
+    "\"\"\")\n",
+    "\n",
+    "for t in [\"knowledge_base_chunk\", \"knowledge_base_document\",\n",
+    "          \"summarization_memory\", \"conversation_memory\", \"entity_memory\"]:\n",
+    "    try:\n",
+    "        cur.execute(f\"DROP TABLE {t} CASCADE CONSTRAINTS PURGE\")\n",
+    "    except oracledb.DatabaseError:\n",
+    "        pass\n",
+    "\n",
+    "for stmt in [\"DROP PACKAGE set_memory_ctx\", \"DROP CONTEXT memory_ctx\",\n",
+    "             \"DROP FUNCTION memory_tenant_policy\"]:\n",
+    "    try:\n",
+    "        cur.execute(stmt)\n",
+    "    except oracledb.DatabaseError:\n",
+    "        pass\n",
+    "\n",
+    "conn.commit()\n",
+    "conn.close()\n",
+    "print(\"Cleanup complete.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/two_layer_pattern_walkthrough.ipynb
+++ b/notebooks/two_layer_pattern_walkthrough.ipynb
@@ -4,24 +4,7 @@
    "cell_type": "markdown",
    "id": "50deee74",
    "metadata": {},
-   "source": [
-    "# Persistent Memory and Derived Context: A Two-Layer Pattern for Agents\n",
-    "\n",
-    "Companion notebook for the Oracle AI Database article *Persistent Memory and Derived Context: A Two-Layer Pattern for Agents*. It runs on the schema from the previous articles, From Prompt to Persistence [part 1](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-1-designing-multi-tenant-agent-memory-schemas-for-saas) and [part 2](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-2-putting-the-multi-tenant-agent-memory-schema-to-work), unchanged. Their companion notebook is [multitenant_schema_walkthrough.ipynb](https://github.com/oracle-devrel/oracle-ai-developer-hub/blob/8c9ed028b1bea545f2cbefe057470a0294bf29b7/notebooks/multitenant_schema_walkthrough.ipynb).\n",
-    "\n",
-    "The boundary in this article is logical. Persistent memory is what's true; derived context is that same knowledge shaped for fast retrieval. In a converged store the two share a row: `content` is canonical, the `embedding` column is derived from it. Provenance runs one way, from the embedding back to the content, and because they live in the same row, one ACID write keeps them together. There's no separate derived-layer table. The derived layer is a column.\n",
-    "\n",
-    "The notebook runs the whole pattern against a live database. It builds the schema, writes a fact and its embedding in one statement, then corrects them in one statement and measures that the vector still tracks the fact. It chunks a document into the knowledge-base tables and rebuilds those chunks from the source. And it walks the sync strategies that keep derived context in step with canonical.\n",
-    "\n",
-    "## Prerequisites\n",
-    "\n",
-    "- Oracle AI Database at `localhost:1521/FREEPDB1` (or set `DB_DSN`), with a non-zero `vector_memory_size`.\n",
-    "- A user with `DB_DEVELOPER_ROLE`, `CREATE SESSION`, `CREATE TABLE`, `CREATE MATERIALIZED VIEW`, `EXECUTE ON DBMS_RLS`.\n",
-    "- The ONNX model `ALL_MINILM_L12_V2` (384-dim) loaded.\n",
-    "- A `.env` with `DB_USER`, `DB_PASSWORD`, `DB_DSN`.\n",
-    "\n",
-    "Vectors are `VECTOR(384, FLOAT32)` to match `ALL_MINILM_L12_V2`."
-   ]
+   "source": "# Persistent Memory and Derived Context: A Two-Layer Pattern for Agents\n\nCompanion notebook for the Oracle AI Database article *Persistent Memory and Derived Context: A Two-Layer Pattern for Agents*. It runs on the schema from the previous articles, From Prompt to Persistence [part 1](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-1-designing-multi-tenant-agent-memory-schemas-for-saas) and [part 2](https://blogs.oracle.com/developers/from-prompt-to-persistence-part-2-putting-the-multi-tenant-agent-memory-schema-to-work), unchanged. Their companion notebook is [multitenant_schema_walkthrough.ipynb](multitenant_schema_walkthrough.ipynb).\n\nThe boundary in this article is logical. Persistent memory is what's true; derived context is that same knowledge shaped for fast retrieval. In a converged store the two share a row: `content` is canonical, the `embedding` column is derived from it. Provenance runs one way, from the embedding back to the content, and because they live in the same row, one ACID write keeps them together. There's no separate derived-layer table. The derived layer is a column.\n\nThe notebook runs the whole pattern against a live database. It builds the schema, writes a fact and its embedding in one statement, then corrects them in one statement and measures that the vector still tracks the fact. It chunks a document into the knowledge-base tables and rebuilds those chunks from the source. And it walks the sync strategies that keep derived context in step with canonical.\n\n## Prerequisites\n\n- Oracle AI Database at `localhost:1521/FREEPDB1` (or set `DB_DSN`), with a non-zero `vector_memory_size`.\n- A user with `DB_DEVELOPER_ROLE`, `CREATE SESSION`, `CREATE TABLE`, `CREATE MATERIALIZED VIEW`, `EXECUTE ON DBMS_RLS`.\n- The ONNX model `ALL_MINILM_L12_V2` (384-dim) loaded.\n- A `.env` with `DB_USER`, `DB_PASSWORD`, `DB_DSN`.\n\nVectors are `VECTOR(384, FLOAT32)` to match `ALL_MINILM_L12_V2`."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

- Adds `notebooks/two_layer_pattern_walkthrough.ipynb`, the companion notebook for the article *Persistent Memory and Derived Context: A Two-Layer Pattern for Agents*. It runs the whole pattern against a live Oracle AI Database: canonical `content` and its derived `embedding` on the same row, a transactional supersede that moves both together (no drift, measured), knowledge-base chunk-and-rebuild, and the three sync strategies (transactional / scheduled MV / lazy).
- Builds directly on the multi-tenant memory schema from the *From Prompt to Persistence* two-part series, reusing its tables and row-level-security setup unchanged.
- The companion link to `multitenant_schema_walkthrough.ipynb` uses a repo-relative path so it resolves correctly on GitHub across forks, branches, and squash-merges.

## Stacked on #221

This branch is stacked on top of #221 (multi-tenant schema walkthrough). Until #221 merges, this PR's diff also shows the `multitenant_schema_walkthrough.ipynb` changes from that PR. Once #221 merges into `main`, GitHub recomputes this diff and only the two-layer notebook remains. Review/merge #221 first.

Relates to #221

## Test Plan

- [x] Notebook executes top to bottom against Oracle AI Database 23.26.1 (`localhost:1521/FREEPDB1`) with `ALL_MINILM_L12_V2` loaded; committed outputs reflect a clean run.
- [x] No-drift check passes: stored embedding vs. current content distance ≈ 0.000000, vs. old content 0.016073.
- [x] Chunk rebuild path verified (max=80 → 2 chunks; max=40 → 4 chunks; canonical document row unchanged).
- [x] Scheduled MV path demonstrates the ORA-30372 RLS conflict and the detach/create/reattach workaround.
- [x] Companion-notebook link resolves (repo-relative); notebook re-parses as valid JSON.
