### PR TITLE
chore: remove accidentally committed .omx agent state files from main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,9 @@ notebooks/config.yaml
 !apps/tanstack-shoe-store/.vscode/
 
 build-paths/tests/
+
+# Local AI tooling output (.omx, distinct from already-ignored .omc)
+.omx/
+
+# Local CYP 2026-05 guide diagrams/visuals - not committed upstream
+guides/cyp-2026-05/

--- a/.omx/metrics.json
+++ b/.omx/metrics.json
@@ -1,8 +1,0 @@
-{
-  "total_turns": 1,
-  "session_turns": 1,
-  "last_activity": "2026-05-19T21:01:35.232Z",
-  "session_input_tokens": 0,
-  "session_output_tokens": 0,
-  "session_total_tokens": 0
-}

--- a/.omx/state/hud-state.json
+++ b/.omx/state/hud-state.json
@@ -1,6 +1,0 @@
-{
-  "last_turn_at": "2026-05-19T21:01:35.314Z",
-  "turn_count": 1,
-  "last_progress_at": "2026-05-19T21:01:35.314Z",
-  "last_agent_output": "I didn’t find a literal Tavily key stored in the enterprise workshop app.\n\nThe relevant entry is in "
-}

--- a/.omx/state/notify-hook-state.json
+++ b/.omx/state/notify-hook-state.json
@@ -1,6 +1,0 @@
-{
-  "recent_turns": {
-    "019e420a-4d6c-7df1-9cd9-78a87f4af3ac|019e420a-6f49-7d72-a8e8-a0c44f6d1d5d|agent-turn-complete": 1779224495228
-  },
-  "last_event_at": "2026-05-19T21:01:35.228Z"
-}

--- a/.omx/state/team-leader-nudge.json
+++ b/.omx/state/team-leader-nudge.json
@@ -1,5 +1,0 @@
-{
-  "last_nudged_by_team": {},
-  "last_idle_nudged_by_team": {},
-  "progress_by_team": {}
-}

--- a/.omx/state/tmux-hook-state.json
+++ b/.omx/state/tmux-hook-state.json
@@ -1,9 +1,0 @@
-{
-  "total_injections": 0,
-  "pane_counts": {},
-  "session_counts": {},
-  "recent_keys": {},
-  "last_injection_ts": 0,
-  "last_reason": "disabled",
-  "last_event_at": "2026-05-19T21:01:35.317Z"
-}


### PR DESCRIPTION
Removes `.omx/` state files (metrics, hud, notify, team-leader, tmux-hook) that were accidentally swept into main by PR #236 resolution, and adds the local gitignore rules (.omx/, in-progress cyper decks) so local tooling output is not committed.

Related: https://github.com/oracle-devrel/oracle-ai-developer-hub/pull/283