### PR TITLE
Add FreeSQL connection guide to custom memory notebook

### DIFF
--- a/notebooks/agent_memory/custom_memory_extraction_agent_memory.ipynb
+++ b/notebooks/agent_memory/custom_memory_extraction_agent_memory.ipynb
@@ -1,1768 +1,1803 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "87541d19",
-   "metadata": {},
-   "source": [
-    "# Custom Memory Extraction for Oracle AI Agent Memory\n",
-    "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Ela689/oracle-ai-developer-hub/blob/feature/custom-memory-extraction-notebook/notebooks/agent_memory/custom_memory_extraction_agent_memory.ipynb) [![Oracle AI Agent Memory docs](https://img.shields.io/badge/Docs-Oracle%20AI%20Agent%20Memory-C74634?logo=oracle&logoColor=white)](https://docs.oracle.com/en/database/oracle/agent-memory/26.6/)\n",
-    "\n",
-    "This notebook is an end-to-end customer support use case for domain-specific memory extraction with Oracle AI Agent Memory. It shows how a general extraction baseline can be extended with workflow-specific instructions when an application needs a more precise memory policy.\n",
-    "\n",
-    "**Thesis:** memory extraction is a domain policy, not just a summarization step. The agent should preserve useful support facts that can help future work, not every detail from the conversation.\n",
-    "\n",
-    "In this support scenario, useful memories include exact order IDs, return requests, tool-confirmed statuses, escalation commitments, and stable delivery preferences. Temporary codes, credentials, payment details, and conversational noise should not become durable memory. The workflow compares baseline extraction with a custom support memory policy, then applies the same pattern to thread-level overrides and tool-result metadata.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8dd214ef",
-   "metadata": {},
-   "source": [
-    "## What This Notebook Demonstrates\n",
-    "\n",
-    "| Area | What you will run | Why it matters |\n",
-    "|---|---|---|\n",
-    "| FreeSQL connection | Connect to a FreeSQL Oracle Database schema and verify table permissions | The notebook uses a lightweight hosted Oracle Database setup while still exercising real database-backed memory storage |\n",
-    "| Support policy use case | Process a customer-support conversation with order IDs, return requests, delivery issues, escalation commitments, and preferences | The use case gives the extractor clear domain priorities for what should become durable memory |\n",
-    "| Baseline vs custom extraction | Compare general extraction with support-specific extraction instructions | The comparison shows how custom instructions refine memory formation for a specific workflow |\n",
-    "| Thread-level control | Override, update, and clear extraction instructions for one support workflow | Different threads can use different memory policies without changing the global client configuration |\n",
-    "| Tool metadata | Preserve tool-confirmed support facts and inherit shared tool/workflow metadata | Tool tags such as `tool:order_status` make extracted memories easier to govern and retrieve later |\n",
-    "| Scoped retrieval checks | Inspect extracted records and search with metadata filters | Memory should be useful, searchable, and controlled by tenant, source, tag, and workflow |\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4a92e9f7",
-   "metadata": {},
-   "source": [
-    "## Conceptual Flow\n",
-    "\n",
-    "The use case starts with one support conversation and sends it through two extraction paths. The baseline path shows the general behavior. The custom path adds a support-specific memory policy that describes durable support facts and exclusions.\n",
-    "\n",
-    "| Stage | Baseline path | Custom extraction path |\n",
-    "|---|---|---|\n",
-    "| Input | Same support conversation | Same support conversation plus support policy and metadata |\n",
-    "| Extraction behavior | General extraction baseline | Support-specific policy for durable facts and exclusions |\n",
-    "| Memory output | Baseline memories | Support memories: orders, returns, preferences, escalations, and tool-confirmed facts |\n",
-    "| Storage | Oracle Database records and metadata | Oracle Database records and inherited workflow metadata |\n",
-    "| Later use | General inspection and search | Scoped retrieval for reusable agent memory context |\n",
-    "\n",
-    "In short:\n",
-    "\n",
-    "```text\n",
-    "Support conversation\n",
-    "        |\n",
-    "        +--> Baseline extraction --> Baseline memories\n",
-    "        |\n",
-    "        +--> Custom support policy + workflow metadata\n",
-    "                 |\n",
-    "                 +--> Support memories: orders, returns, preferences, escalations\n",
-    "                          |\n",
-    "                          +--> Oracle Database records + metadata\n",
-    "                                   |\n",
-    "                                   +--> Scoped retrieval for future agent context\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2cd7cb27",
-   "metadata": {},
-   "source": [
-    "# Part 1 - Setup and Database Connection\n",
-    "\n",
-    "This section prepares a clean runtime:\n",
-    "\n",
-    "1. install the required Python packages;\n",
-    "2. choose an Oracle Database connection, including FreeSQL for a quick hosted schema;\n",
-    "3. configure the LLM and embedding route used by the full example.\n",
-    "\n",
-    "FreeSQL is useful when you want a fast Oracle Database connection without running a local container. For a\n",
-    "fully self-contained local run, you can also use Oracle Database Free in Docker.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "027a6aac",
-   "metadata": {},
-   "source": [
-    "## Install the Python Packages\n",
-    "\n",
-    "Install the package from PyPI. The `[litellm]` extra lets Oracle AI Agent Memory call configured chat and\n",
-    "embedding providers through one interface. `oracledb` is the Oracle Database driver, `pandas` is used to\n",
-    "display results, and `python-dotenv` is a local-development convenience for loading environment values.\n",
-    "\n",
-    "Run this once in a clean environment. A dedicated virtual environment is recommended so the database driver,\n",
-    "LLM dependencies, and memory package can be upgraded and tested together.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "2ce80e4a",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Python packages: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "import sys\n",
-    "from importlib.metadata import version\n",
-    "\n",
-    "from IPython.utils.capture import capture_output\n",
-    "\n",
-    "\n",
-    "assert (3, 10) <= sys.version_info[:2] <= (3, 13), (\n",
-    "    f\"Python 3.10-3.13 is required; found {sys.version.split()[0]}\"\n",
-    ")\n",
-    "\n",
-    "with capture_output():\n",
-    "    get_ipython().run_line_magic(\n",
-    "        \"pip\",\n",
-    "        \"install --upgrade oracleagentmemory[litellm]==26.6.0 oracledb pandas python-dotenv --quiet\",\n",
-    "    )\n",
-    "\n",
-    "package_version = version(\"oracleagentmemory\")\n",
-    "assert package_version == \"26.6.0\", (\n",
-    "    f\"Oracle AI Agent Memory 26.6.0 is required; found {package_version}\"\n",
-    ")\n",
-    "\n",
-    "print(\"Python packages: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e857c2d",
-   "metadata": {},
-   "source": [
-    "## Option A - FreeSQL Connection Setup\n",
-    "\n",
-    "FreeSQL gives developers a quick Oracle Database schema at [freesql.com](https://freesql.com). After signing in, open **Connect to the Database**, choose **Python**, and copy the username, generated password, and DSN.\n",
-    "\n",
-    "Set these values as environment variables before running the notebook:\n",
-    "\n",
-    "```text\n",
-    "DB_USER=<FreeSQL schema username>\n",
-    "DB_PASSWORD=<generated FreeSQL schema password>\n",
-    "DB_CONNECT_STRING=tcps://db.freesql.com:2484/<FreeSQL service name>\n",
-    "# DB_DSN is also accepted as an alias for DB_CONNECT_STRING.\n",
-    "```\n",
-    "\n",
-    "The next setup cell opens a real Oracle Database connection and verifies that the schema can create and remove a small table.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "91f28e1a",
-   "metadata": {},
-   "source": [
-    "## Optional Fallback - Standalone Oracle Database Setup with Docker\n",
-    "\n",
-    "Use Oracle Database Free in Docker when you want a reproducible local database for the full example.\n",
-    "\n",
-    "```bash\n",
-    "docker pull gvenzl/oracle-free:23.26.2\n",
-    "docker volume create oracle-free-data\n",
-    "\n",
-    "docker run -d \\\n",
-    "  --name oracle-ai-memory-example \\\n",
-    "  -p 1522:1521 \\\n",
-    "  -e ORACLE_PASSWORD=\"<admin-password>\" \\\n",
-    "  -e APP_USER=\"<app-user>\" \\\n",
-    "  -e APP_USER_PASSWORD=\"<app-password>\" \\\n",
-    "  -v oracle-free-data:/opt/oracle/oradata \\\n",
-    "  gvenzl/oracle-free:23.26.2\n",
-    "\n",
-    "docker logs -f oracle-ai-memory-example\n",
-    "```\n",
-    "\n",
-    "Then configure the active connection:\n",
-    "\n",
-    "```text\n",
-    "DB_USER=<app-user>\n",
-    "DB_PASSWORD=<app-password>\n",
-    "DB_CONNECT_STRING=localhost:1522/FREEPDB1\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "23c44407",
-   "metadata": {},
-   "source": [
-    "## Runtime Configuration\n",
-    "\n",
-    "The notebook needs one Oracle Database connection and one model provider key for memory extraction:\n",
-    "\n",
-    "| Variable | Purpose |\n",
-    "|---|---|\n",
-    "| `DB_USER` | Oracle Database schema user |\n",
-    "| `DB_PASSWORD` | Password for the schema user |\n",
-    "| `DB_CONNECT_STRING` | Oracle Database connect string or descriptor |\n",
-    "| `MODEL_PROVIDER_API_KEY` | Provider key used by the configured memory extraction LLM |\n",
-    "| `MEMORY_LLM_MODEL` | Chat model used for memory extraction |\n",
-    "\n",
-    "For retrieval, use one of these routes:\n",
-    "\n",
-    "| Route | When to use it | Required variables |\n",
-    "|---|---|---|\n",
-    "| `EMBED_BACKEND=provider` | Default FreeSQL-friendly route for this custom extraction notebook | none beyond the model provider key |\n",
-    "| `EMBED_BACKEND=indb` | Oracle-native route when a database-resident embedding model is available | `DB_EMBED_MODEL`, `DB_EMBED_DIM` |\n",
-    "\n",
-    "The default route keeps retrieval lightweight so the notebook can focus on custom extraction behavior. In an Oracle AI Database environment with a visible embedding model, switch to `EMBED_BACKEND=indb` to use `OracleDBEmbedder`.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8e9fdd79",
-   "metadata": {},
-   "source": [
-    "## Load Local Environment Values\n",
-    "\n",
-    "This cell loads local environment values when present. Public runners can set the same values directly as\n",
-    "environment variables.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "87c51737",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Runtime configuration loader: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "from pathlib import Path\n",
-    "\n",
-    "from dotenv import load_dotenv\n",
-    "\n",
-    "\n",
-    "load_dotenv(Path.cwd() / \".env\")\n",
-    "\n",
-    "print(\"Runtime configuration loader: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d7e6c632",
-   "metadata": {},
-   "source": [
-    "## Read and Validate Configuration\n",
-    "\n",
-    "The notebook validates only whether required values exist. It does not print usernames, passwords, DSNs,\n",
-    "schema names, database versions, or local paths.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "7d7a7f1d",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Required configuration: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "import os\n",
-    "\n",
-    "import pandas as pd\n",
-    "\n",
-    "\n",
-    "CONFIG = {\n",
-    "    \"DB_USER\": os.getenv(\"DB_USER\") or os.getenv(\"ORACLE_USER\"),\n",
-    "    \"DB_PASSWORD\": os.getenv(\"DB_PASSWORD\") or os.getenv(\"ORACLE_PASSWORD\"),\n",
-    "    \"DB_CONNECT_STRING\": os.getenv(\"DB_CONNECT_STRING\") or os.getenv(\"DB_DSN\") or os.getenv(\"ORACLE_DSN\"),\n",
-    "    \"MODEL_PROVIDER_API_KEY\": os.getenv(\"MODEL_PROVIDER_API_KEY\") or os.getenv(\"MEMORY_LLM_API_KEY\"),\n",
-    "    \"MEMORY_LLM_API_BASE\": os.getenv(\"MEMORY_LLM_API_BASE\"),\n",
-    "    \"MEMORY_LLM_API_TYPE\": os.getenv(\"MEMORY_LLM_API_TYPE\", \"chat_completions\"),\n",
-    "    \"MEMORY_LLM_MODEL\": os.getenv(\"MEMORY_LLM_MODEL\") or \"gpt-4o-mini\",\n",
-    "    \"EMBED_BACKEND\": os.getenv(\"EMBED_BACKEND\", \"provider\").lower(),\n",
-    "    \"EMBED_MODEL\": os.getenv(\"EMBED_MODEL\", \"text-embedding-3-small\"),\n",
-    "    \"EMBED_DIM\": int(os.getenv(\"EMBED_DIM\", \"1536\")),\n",
-    "    \"DB_EMBED_MODEL\": os.getenv(\"DB_EMBED_MODEL\") or os.getenv(\"ORACLE_DB_EMBEDDING_MODEL\"),\n",
-    "    \"DB_EMBED_DIM\": os.getenv(\"DB_EMBED_DIM\") or os.getenv(\"ORACLE_DB_EMBEDDING_DIMENSION\"),\n",
-    "    \"DB_EMBED_INPUT\": os.getenv(\"DB_EMBED_INPUT\", \"DATA\"),\n",
-    "}\n",
-    "\n",
-    "\n",
-    "required = {\n",
-    "    \"DB_USER\": \"DB_USER or ORACLE_USER\",\n",
-    "    \"DB_PASSWORD\": \"DB_PASSWORD or ORACLE_PASSWORD\",\n",
-    "    \"DB_CONNECT_STRING\": \"DB_CONNECT_STRING, DB_DSN, or ORACLE_DSN\",\n",
-    "    \"MODEL_PROVIDER_API_KEY\": \"MODEL_PROVIDER_API_KEY or MEMORY_LLM_API_KEY\",\n",
-    "}\n",
-    "missing = [label for key, label in required.items() if not CONFIG.get(key)]\n",
-    "if missing:\n",
-    "    raise RuntimeError(\n",
-    "        \"Missing required environment values: \"\n",
-    "        + \", \".join(missing)\n",
-    "        + \". Add them before running the notebook.\"\n",
-    "    )\n",
-    "\n",
-    "print(\"Required configuration: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6632f597",
-   "metadata": {},
-   "source": [
-    "## Create and Verify the Oracle Database Connection Pool\n",
-    "\n",
-    "This cell creates the Oracle Database connection pool used by the notebook. When the connection string points to FreeSQL, it also verifies the FreeSQL setup requested for this content.\n",
-    "\n",
-    "A pool is used instead of a single raw connection because Oracle AI Agent Memory can perform several kinds of database work during a realistic application flow: message writes, memory extraction, memory inspection, and retrieval. Even in a notebook, using a pool mirrors the application pattern more closely.\n",
-    "\n",
-    "The check intentionally prints only readiness status. It does not display usernames, schema names, DSNs, passwords, database versions, or local paths.\n",
-    "\n",
-    "It verifies:\n",
-    "\n",
-    "- Python can connect to the configured Oracle Database service;\n",
-    "- a simple `SELECT 1 FROM dual` query succeeds;\n",
-    "- the schema can create, insert into, read from, and drop a small table.\n",
-    "\n",
-    "The table-permission check matters because Oracle AI Agent Memory creates and manages its own database objects during schema setup.\n",
-    "\n",
-    "The connection also sets a Developer Hub program identifier before the pool is created, so usage can be recognized in Oracle Developer Hub telemetry.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "f18f359d",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FreeSQL connection and table permissions: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "import oracledb\n",
-    "from uuid import uuid4\n",
-    "\n",
-    "\n",
-    "oracledb.defaults.program = \"devrel-developerhub-custom-memory-extraction-agent-memory\"\n",
-    "\n",
-    "\n",
-    "db_pool = oracledb.create_pool(\n",
-    "    user=CONFIG[\"DB_USER\"],\n",
-    "    password=CONFIG[\"DB_PASSWORD\"],\n",
-    "    dsn=CONFIG[\"DB_CONNECT_STRING\"],\n",
-    "    min=1,\n",
-    "    max=4,\n",
-    "    increment=1,\n",
-    ")\n",
-    "\n",
-    "permission_check_table = f\"OAM_FREESQL_CHECK_{uuid4().hex[:8].upper()}\"\n",
-    "\n",
-    "try:\n",
-    "    with db_pool.acquire() as connection:\n",
-    "        with connection.cursor() as cursor:\n",
-    "            cursor.execute(\"SELECT 1 FROM dual\").fetchone()\n",
-    "            cursor.execute(\n",
-    "                f\"\"\"\n",
-    "                CREATE TABLE {permission_check_table} (\n",
-    "                    id NUMBER PRIMARY KEY,\n",
-    "                    note VARCHAR2(100)\n",
-    "                )\n",
-    "                \"\"\"\n",
-    "            )\n",
-    "            cursor.execute(\n",
-    "                f\"INSERT INTO {permission_check_table} (id, note) VALUES (:id, :note)\",\n",
-    "                id=1,\n",
-    "                note=\"table permission check\",\n",
-    "            )\n",
-    "            count = cursor.execute(\n",
-    "                f\"SELECT COUNT(*) FROM {permission_check_table}\"\n",
-    "            ).fetchone()[0]\n",
-    "            if count != 1:\n",
-    "                raise RuntimeError(\"Table permission check returned an unexpected row count.\")\n",
-    "        connection.commit()\n",
-    "finally:\n",
-    "    try:\n",
-    "        with db_pool.acquire() as cleanup_connection:\n",
-    "            with cleanup_connection.cursor() as cursor:\n",
-    "                cursor.execute(f\"DROP TABLE {permission_check_table} PURGE\")\n",
-    "            cleanup_connection.commit()\n",
-    "    except oracledb.Error:\n",
-    "        pass\n",
-    "\n",
-    "print(\"FreeSQL connection and table permissions: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f99c799",
-   "metadata": {},
-   "source": [
-    "## Choose the Retrieval Route\n",
-    "\n",
-    "This notebook focuses on custom memory extraction, so the default FreeSQL path uses keyword retrieval. That keeps the workflow lightweight while still using Oracle AI Agent Memory for database-backed storage, extraction, thread control, metadata, and scoped search.\n",
-    "\n",
-    "For Oracle AI Database environments where a database-resident embedding model is available, switch to `EMBED_BACKEND=indb` to use `OracleDBEmbedder` and hybrid retrieval with the same memory APIs.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "fcd2c59b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Retrieval route: portable keyword search\n"
-     ]
-    }
-   ],
-   "source": [
-    "from oracleagentmemory.core import SearchIndexSyncMode, SearchStrategy\n",
-    "from oracleagentmemory.core.embedders import Embedder, OracleDBEmbedder\n",
-    "\n",
-    "\n",
-    "EMBED_BACKEND = CONFIG[\"EMBED_BACKEND\"]\n",
-    "\n",
-    "if EMBED_BACKEND == \"indb\":\n",
-    "    missing_indb = [\n",
-    "        name\n",
-    "        for name in [\"DB_EMBED_MODEL\", \"DB_EMBED_DIM\"]\n",
-    "        if not CONFIG.get(name) or str(CONFIG.get(name)).startswith(\"<\")\n",
-    "    ]\n",
-    "    if missing_indb:\n",
-    "        raise RuntimeError(\n",
-    "            \"EMBED_BACKEND=indb requires: \"\n",
-    "            + \", \".join(missing_indb)\n",
-    "            + \". Use EMBED_BACKEND=provider for a portable run, or configure a visible database embedding model.\"\n",
-    "        )\n",
-    "\n",
-    "    embedder = OracleDBEmbedder(\n",
-    "        connection=db_pool,\n",
-    "        model=CONFIG[\"DB_EMBED_MODEL\"],\n",
-    "        input_name=CONFIG[\"DB_EMBED_INPUT\"],\n",
-    "        embedding_dimension=int(CONFIG[\"DB_EMBED_DIM\"]),\n",
-    "        max_input_tokens=512,\n",
-    "        normalize=True,\n",
-    "        batch_size=16,\n",
-    "    )\n",
-    "    SEARCH_STRATEGY = SearchStrategy.HYBRID\n",
-    "    SEARCH_INDEX_SYNC = SearchIndexSyncMode.ON_COMMIT\n",
-    "    VECTOR_DIM = None\n",
-    "    print(\"Embedding route: OracleDBEmbedder\")\n",
-    "\n",
-    "elif EMBED_BACKEND == \"provider\":\n",
-    "    # The portable FreeSQL path keeps retrieval keyword-based so the notebook\n",
-    "    # can run without creating database vector indexes. The LLM provider is\n",
-    "    # still used for memory extraction.\n",
-    "    embedder = None\n",
-    "    SEARCH_STRATEGY = SearchStrategy.KEYWORD\n",
-    "    SEARCH_INDEX_SYNC = None\n",
-    "    VECTOR_DIM = None\n",
-    "    print(\"Retrieval route: portable keyword search\")\n",
-    "\n",
-    "else:\n",
-    "    raise RuntimeError(\"EMBED_BACKEND must be either 'indb' or 'provider'.\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "20e45a73",
-   "metadata": {},
-   "source": [
-    "## Configure the Memory Extraction LLM\n",
-    "\n",
-    "The LLM is used by Oracle AI Agent Memory to transform raw conversation messages into durable memory records. Retrieval configuration is handled separately, so the notebook can demonstrate the extraction policy independently from the retrieval backend.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "eda4fa11",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Memory extraction LLM: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "from oracleagentmemory.core.llms import Llm, LlmApiType\n",
-    "\n",
-    "\n",
-    "llm_kwargs = {\n",
-    "    \"model\": CONFIG[\"MEMORY_LLM_MODEL\"],\n",
-    "    \"api_key\": CONFIG[\"MODEL_PROVIDER_API_KEY\"],\n",
-    "    \"temperature\": 0,\n",
-    "    \"max_tokens\": 2_000,\n",
-    "}\n",
-    "if CONFIG[\"MEMORY_LLM_API_BASE\"]:\n",
-    "    llm_kwargs[\"api_base\"] = CONFIG[\"MEMORY_LLM_API_BASE\"]\n",
-    "if CONFIG[\"MEMORY_LLM_API_TYPE\"] == \"responses\":\n",
-    "    llm_kwargs[\"api_type\"] = LlmApiType.RESPONSES\n",
-    "\n",
-    "memory_llm = Llm(**llm_kwargs)\n",
-    "\n",
-    "print(\"Memory extraction LLM: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "259ae8e1",
-   "metadata": {},
-   "source": [
-    "# Part 2 - Extraction Policy and Memory Clients\n",
-    "\n",
-    "This section defines the support-specific extraction policy and creates two memory clients over the same database-backed store:\n",
-    "\n",
-    "- a baseline client that uses the package's general extraction behavior;\n",
-    "- a custom client that adds support-specific extraction instructions.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "09aab796",
-   "metadata": {},
-   "source": [
-    "## Define Domain-Specific Extraction Instructions\n",
-    "\n",
-    "Custom extraction instructions are appended to the built-in extraction prompt. In this example, the instructions define the support team's memory policy: preserve durable business facts and exact identifiers, and avoid temporary or sensitive details.\n",
-    "\n",
-    "Good instructions describe business intent and exclusions. They should guide memory formation without depending on provider-specific output formatting.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "b1e70f25",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Support extraction policy: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "SUPPORT_EXTRACTION_INSTRUCTIONS = \"\"\"\n",
-    "Extract only durable customer-support memory that can help future support interactions.\n",
-    "\n",
-    "Preserve:\n",
-    "- confirmed order identifiers, return identifiers, case identifiers, and return requests;\n",
-    "- delivery problems, product defects, replacement commitments, and escalation reasons;\n",
-    "- stable customer preferences that should influence future interactions;\n",
-    "- tool-derived support facts when the source message metadata identifies a tool result.\n",
-    "\n",
-    "Ignore:\n",
-    "- greetings, small talk, apologies, and temporary conversational wording;\n",
-    "- speculation or unconfirmed guesses;\n",
-    "- credentials, payment secrets, one-time verification codes, and unnecessary sensitive data.\n",
-    "\n",
-    "Prefer concise facts, preferences, or guidelines. Keep exact identifiers when they matter.\n",
-    "\"\"\".strip()\n",
-    "\n",
-    "print(\"Support extraction policy: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "08612057",
-   "metadata": {},
-   "source": [
-    "## Define Example Scope\n",
-    "\n",
-    "The run-specific IDs keep repeated notebook executions isolated from each other.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "a490da8c",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Example scope: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "from uuid import uuid4\n",
-    "\n",
-    "\n",
-    "RUN_ID = uuid4().hex[:8]\n",
-    "MEMORY_STORE_ID = \"CUST_EXTRACT\"\n",
-    "USER_ID = f\"customer_custom_extract_{RUN_ID}\"\n",
-    "AGENT_ID = f\"support_agent_{RUN_ID}\"\n",
-    "\n",
-    "print(\"Example scope: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "90d437c2",
-   "metadata": {},
-   "source": [
-    "## Create the Database Stores\n",
-    "\n",
-    "The helper below passes `search_index_sync` only when the selected search strategy supports it. This matters\n",
-    "because vector-only search does not use the text-search index sync setting.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "8de4f70e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Database-backed memory stores: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "import contextlib\n",
-    "import io\n",
-    "import warnings\n",
-    "\n",
-    "from oracleagentmemory.core import OracleDBMemoryStore, SchemaPolicy\n",
-    "\n",
-    "\n",
-    "def build_store(schema_policy):\n",
-    "    store_kwargs = {\n",
-    "        \"pool\": db_pool,\n",
-    "        \"embedder\": embedder,\n",
-    "        \"memory_store_id\": MEMORY_STORE_ID,\n",
-    "        \"schema_policy\": schema_policy,\n",
-    "        \"search_strategy\": SEARCH_STRATEGY,\n",
-    "        \"vector_dim\": VECTOR_DIM,\n",
-    "    }\n",
-    "    if SEARCH_INDEX_SYNC is not None:\n",
-    "        store_kwargs[\"search_index_sync\"] = SEARCH_INDEX_SYNC\n",
-    "    return OracleDBMemoryStore(**store_kwargs)\n",
-    "\n",
-    "\n",
-    "suppressed_stderr = io.StringIO()\n",
-    "with warnings.catch_warnings():\n",
-    "    warnings.simplefilter(\"ignore\", category=UserWarning)\n",
-    "    with contextlib.redirect_stderr(suppressed_stderr):\n",
-    "        base_store = build_store(SchemaPolicy.CREATE_IF_NECESSARY)\n",
-    "        custom_store = build_store(SchemaPolicy.REQUIRE_EXISTING)\n",
-    "\n",
-    "print(\"Database-backed memory stores: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dd3e5d69",
-   "metadata": {},
-   "source": [
-    "## Create Baseline and Custom Memory Clients\n",
-    "\n",
-    "The baseline client uses the general extraction behavior. The custom client uses the same database store and LLM, but adds support-specific extraction instructions through `MemoryExtractionConfig`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "c44ca6ca",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Default and custom memory clients: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "from oracleagentmemory.core import MemoryExtractionConfig, OracleAgentMemory\n",
-    "\n",
-    "\n",
-    "base_memory = OracleAgentMemory(\n",
-    "    store=base_store,\n",
-    "    llm=memory_llm,\n",
-    "    memory_extraction_config=MemoryExtractionConfig(\n",
-    "        memory_extraction_frequency=1,\n",
-    "        enable_context_summary=False,\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "custom_memory = OracleAgentMemory(\n",
-    "    store=custom_store,\n",
-    "    llm=memory_llm,\n",
-    "    memory_extraction_config=MemoryExtractionConfig(\n",
-    "        memory_extraction_frequency=1,\n",
-    "        enable_context_summary=False,\n",
-    "        memory_extraction_custom_instructions=SUPPORT_EXTRACTION_INSTRUCTIONS,\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "print(\"Default and custom memory clients: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b2effb03",
-   "metadata": {},
-   "source": [
-    "# Part 3 - Baseline vs Custom Extraction\n",
-    "\n",
-    "This is the core use-case section. The same support conversation is processed twice so the difference is easy to inspect:\n",
-    "\n",
-    "- **Baseline extraction** shows the general extraction behavior.\n",
-    "- **Custom extraction** adds a support memory policy for durable support facts, exact identifiers, and temporary or sensitive details that should be ignored.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "015ef234",
-   "metadata": {},
-   "source": [
-    "## Prepare the Support Conversation\n",
-    "\n",
-    "The conversation deliberately includes information with different memory lifecycles.\n",
-    "\n",
-    "Durable support facts:\n",
-    "\n",
-    "- order ID and damaged product detail;\n",
-    "- return request and replacement delivery intent;\n",
-    "- stable delivery preference;\n",
-    "- escalation condition.\n",
-    "\n",
-    "Short-lived or sensitive details:\n",
-    "\n",
-    "- greeting and conversational wording;\n",
-    "- temporary lobby code;\n",
-    "- anything that looks like a one-time or sensitive detail.\n",
-    "\n",
-    "This makes the use case practical: the custom policy is not trying to replace general extraction; it adds domain guidance for what this support workflow considers reusable memory.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "a1cb5abb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Support conversation: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "SUPPORT_CONVERSATION = [\n",
-    "    {\n",
-    "        \"role\": \"user\",\n",
-    "        \"content\": (\n",
-    "            \"Hi! Order ORD-7421 arrived damaged. The left hinge is cracked, \"\n",
-    "            \"and I need a return request plus a replacement delivery. \"\n",
-    "            \"My temporary lobby code today is 4812, but please do not save that.\"\n",
-    "        ),\n",
-    "    },\n",
-    "    {\n",
-    "        \"role\": \"assistant\",\n",
-    "        \"content\": (\n",
-    "            \"I can help with order ORD-7421. I will start a return request and \"\n",
-    "            \"mark the damaged hinge as the replacement reason.\"\n",
-    "        ),\n",
-    "    },\n",
-    "    {\n",
-    "        \"role\": \"user\",\n",
-    "        \"content\": (\n",
-    "            \"For future deliveries, I prefer morning delivery windows. \"\n",
-    "            \"Please escalate if the replacement cannot ship this week.\"\n",
-    "        ),\n",
-    "    },\n",
-    "]\n",
-    "\n",
-    "print(\"Support conversation: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0bdee195",
-   "metadata": {},
-   "source": [
-    "## Run Baseline Extraction\n",
-    "\n",
-    "Baseline extraction provides a general-purpose comparison point. It can capture useful facts from the conversation, but it does not apply the support-specific policy defined above. This lets us compare the general behavior with a custom policy for durable support facts, exact identifiers, and temporary details that should be ignored.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "26c3dd23",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Default extraction thread: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "default_thread = base_memory.create_thread(\n",
-    "    thread_id=f\"default_support_{RUN_ID}\",\n",
-    "    user_id=USER_ID,\n",
-    "    agent_id=AGENT_ID,\n",
-    ")\n",
-    "\n",
-    "await default_thread.add_messages_async(SUPPORT_CONVERSATION)\n",
-    "await default_thread.wait_for_memory_extraction_async()\n",
-    "\n",
-    "print(\"Default extraction thread: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "382b063a",
-   "metadata": {},
-   "source": [
-    "## Run Custom Support Extraction\n",
-    "\n",
-    "The same conversation is now processed with custom extraction instructions. These instructions add the support workflow policy: preserve durable facts such as order IDs, return requests, delivery preferences, and escalation commitments, while avoiding temporary or sensitive details.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "65856227",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Custom extraction thread: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "custom_thread = custom_memory.create_thread(\n",
-    "    thread_id=f\"custom_support_{RUN_ID}\",\n",
-    "    user_id=USER_ID,\n",
-    "    agent_id=AGENT_ID,\n",
-    ")\n",
-    "\n",
-    "await custom_thread.add_messages_async(SUPPORT_CONVERSATION)\n",
-    "await custom_thread.wait_for_memory_extraction_async()\n",
-    "\n",
-    "print(\"Custom extraction thread: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "863fa9ce",
-   "metadata": {},
-   "source": [
-    "## Compare Extracted Memories\n",
-    "\n",
-    "First inspect the records created by the two extraction paths. This is the central comparison in the notebook:\n",
-    "\n",
-    "- **Baseline extraction** shows general memory behavior.\n",
-    "- **Custom extraction** shows support-specific memory behavior shaped by the extraction policy.\n",
-    "\n",
-    "The comparison should make the before/after difference easy to see. Look for whether the custom path preserves durable support facts more directly, such as order IDs, return or replacement details, delivery preferences, escalation commitments, and tool-confirmed support state.\n",
-    "\n",
-    "The other side of the comparison is equally important: temporary details, such as the lobby code, should not become durable memory.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "b8294f43",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Memory inspection helpers: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "RECORD_TYPES_TO_INSPECT = [\"memory\", \"fact\", \"preference\", \"guideline\"]\n",
-    "\n",
-    "\n",
-    "def record_to_row(record):\n",
-    "    return {\n",
-    "        \"record_type\": record.record_type,\n",
-    "        \"content\": getattr(record, \"content\", None) or getattr(record, \"text\", None),\n",
-    "        \"metadata\": record.metadata,\n",
-    "    }\n",
-    "\n",
-    "\n",
-    "def list_extracted_records(store, thread_id):\n",
-    "    rows = []\n",
-    "    for record_type in RECORD_TYPES_TO_INSPECT:\n",
-    "        for record in store.list(record_type, thread_id=thread_id, limit=None):\n",
-    "            rows.append(record_to_row(record))\n",
-    "    return rows\n",
-    "\n",
-    "\n",
-    "async def search_thread_results(thread, queries, *, max_results=5):\n",
-    "    seen = {}\n",
-    "    for query in queries:\n",
-    "        for result in await thread.search_async(\n",
-    "            query,\n",
-    "            max_results=max_results,\n",
-    "            exact_thread_match=True,\n",
-    "            record_types=RECORD_TYPES_TO_INSPECT,\n",
-    "        ):\n",
-    "            record = result.record\n",
-    "            key = getattr(record, \"id\", None) or (record.record_type, result.content)\n",
-    "            seen[key] = {\n",
-    "                \"record_type\": record.record_type,\n",
-    "                \"content\": result.content,\n",
-    "                \"metadata\": record.metadata,\n",
-    "            }\n",
-    "    return list(seen.values())\n",
-    "\n",
-    "\n",
-    "print(\"Memory inspection helpers: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f86ae4bb",
-   "metadata": {},
-   "source": [
-    "### Inspect the Stored Memory Records\n",
-    "\n",
-    "The table below compares the records created by default extraction and by the custom support policy.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "7ff9c7a8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "default_memories = list_extracted_records(base_store, default_thread.thread_id)\n",
-    "custom_memories = list_extracted_records(custom_store, custom_thread.thread_id)\n",
-    "\n",
-    "comparison_columns = [\"extraction\", \"record_type\", \"content\", \"metadata\"]\n",
-    "comparison = pd.DataFrame(\n",
-    "    [{\"extraction\": \"Default\", **row} for row in default_memories]\n",
-    "    + [{\"extraction\": \"Custom support policy\", **row} for row in custom_memories],\n",
-    "    columns=comparison_columns,\n",
-    ")\n",
-    "\n",
-    "if comparison.empty:\n",
-    "    pd.DataFrame([{\"status\": \"No extracted memory records found. Check the extraction LLM configuration and rerun the extraction cells.\"}])\n",
-    "else:\n",
-    "    comparison[comparison_columns]\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a76f1a37",
-   "metadata": {},
-   "source": [
-    "### Lightweight Quality Check\n",
-    "\n",
-    "This check is intentionally simple and readable. It does not grade the model or claim benchmark quality. It verifies the expected behavior for this support use case.\n",
-    "\n",
-    "Expected result:\n",
-    "\n",
-    "- the custom memory output keeps the order ID;\n",
-    "- it keeps return or replacement details;\n",
-    "- it keeps the stable delivery preference;\n",
-    "- it avoids saving temporary details such as the lobby code.\n",
-    "\n",
-    "These checks make the notebook easier to review because they turn the policy goal into concrete output expectations.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "a3ed03af",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>extraction</th>\n",
-       "      <th>mentions_order_id</th>\n",
-       "      <th>mentions_return_or_replacement</th>\n",
-       "      <th>mentions_delivery_preference</th>\n",
-       "      <th>temporary_code_leaked</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Default</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Custom support policy</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              extraction  mentions_order_id  mentions_return_or_replacement  \\\n",
-       "0                Default               True                            True   \n",
-       "1  Custom support policy               True                            True   \n",
-       "\n",
-       "   mentions_delivery_preference  temporary_code_leaked  \n",
-       "0                          True                  False  \n",
-       "1                          True                  False  "
+      "cell_type": "markdown",
+      "id": "87541d19",
+      "metadata": {},
+      "source": [
+        "# Custom Memory Extraction for Oracle AI Agent Memory\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Ela689/oracle-ai-developer-hub/blob/feature/custom-memory-extraction-notebook/notebooks/agent_memory/custom_memory_extraction_agent_memory.ipynb) [![Oracle AI Agent Memory docs](https://img.shields.io/badge/Docs-Oracle%20AI%20Agent%20Memory-C74634?logo=oracle&logoColor=white)](https://docs.oracle.com/en/database/oracle/agent-memory/26.6/)\n",
+        "\n",
+        "This notebook is an end-to-end customer support use case for domain-specific memory extraction with Oracle AI Agent Memory. It shows how a general extraction baseline can be extended with workflow-specific instructions when an application needs a more precise memory policy.\n",
+        "\n",
+        "**Thesis:** memory extraction is a domain policy, not just a summarization step. The agent should preserve useful support facts that can help future work, not every detail from the conversation.\n",
+        "\n",
+        "In this support scenario, useful memories include exact order IDs, return requests, tool-confirmed statuses, escalation commitments, and stable delivery preferences. Temporary codes, credentials, payment details, and conversational noise should not become durable memory. The workflow compares baseline extraction with a custom support memory policy, then applies the same pattern to thread-level overrides and tool-result metadata.\n"
       ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "def score_memory_set(rows):\n",
-    "    text = \" \".join(str(row[\"content\"]).lower() for row in rows)\n",
-    "    return {\n",
-    "        \"mentions_order_id\": \"ord-7421\" in text or \"7421\" in text,\n",
-    "        \"mentions_return_or_replacement\": any(\n",
-    "            token in text for token in [\"return\", \"replacement\", \"replace\"]\n",
-    "        ),\n",
-    "        \"mentions_delivery_preference\": \"morning\" in text and \"delivery\" in text,\n",
-    "        \"temporary_code_leaked\": \"4812\" in text,\n",
-    "    }\n",
-    "\n",
-    "\n",
-    "quality = pd.DataFrame(\n",
-    "    [\n",
-    "        {\"extraction\": \"Default\", **score_memory_set(default_memories)},\n",
-    "        {\"extraction\": \"Custom support policy\", **score_memory_set(custom_memories)},\n",
-    "    ]\n",
-    ")\n",
-    "\n",
-    "quality\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fd7542c9",
-   "metadata": {},
-   "source": [
-    "# Part 4 - Thread-Level Control and Tool Metadata\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bb9c340c",
-   "metadata": {},
-   "source": [
-    "## Override Instructions for One Thread\n",
-    "\n",
-    "Client-level instructions are the default. A thread-level override is useful when one support conversation has\n",
-    "a narrower workflow, such as escalation handling, replacement tracking, or incident follow-up.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "dc745954",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Escalation extraction policy: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "ESCALATION_EXTRACTION_INSTRUCTIONS = \"\"\"\n",
-    "Extract only durable escalation-support facts:\n",
-    "- escalation reasons;\n",
-    "- replacement shipment identifiers;\n",
-    "- customer-facing follow-up commitments;\n",
-    "- deadlines or status checks that should influence future support turns.\n",
-    "Ignore general delivery preferences and unrelated return-request details.\n",
-    "\"\"\".strip()\n",
-    "\n",
-    "print(\"Escalation extraction policy: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "76c82c18",
-   "metadata": {},
-   "source": [
-    "### Run an Escalation-Specific Thread\n",
-    "\n",
-    "This thread overrides the broader support policy with narrower escalation-specific instructions for one\n",
-    "conversation.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "afa2a16b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Escalation extraction thread: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "escalation_thread = custom_memory.create_thread(\n",
-    "    thread_id=f\"escalation_support_{RUN_ID}\",\n",
-    "    user_id=USER_ID,\n",
-    "    agent_id=AGENT_ID,\n",
-    "    memory_extraction_config=MemoryExtractionConfig(\n",
-    "        memory_extraction_frequency=1,\n",
-    "        enable_context_summary=False,\n",
-    "        memory_extraction_custom_instructions=ESCALATION_EXTRACTION_INSTRUCTIONS,\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "await escalation_thread.add_messages_async(\n",
-    "    [\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": (\n",
-    "                \"Replacement shipment RMA-8842 for order ORD-7421 still has not shipped. \"\n",
-    "                \"Please escalate because the customer needs a status update by Friday.\"\n",
-    "            ),\n",
-    "        },\n",
-    "        {\n",
-    "            \"role\": \"assistant\",\n",
-    "            \"content\": (\n",
-    "                \"I will escalate replacement shipment RMA-8842 and track the Friday follow-up commitment.\"\n",
-    "            ),\n",
-    "        },\n",
-    "    ]\n",
-    ")\n",
-    "await escalation_thread.wait_for_memory_extraction_async()\n",
-    "\n",
-    "print(\"Escalation extraction thread: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ac893ce9",
-   "metadata": {},
-   "source": [
-    "### Inspect Escalation Memories\n",
-    "\n",
-    "Inspect the records extracted from the overridden thread. The expected output is narrower than the broader support policy because this thread focuses on escalation and shipment follow-up.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "1534c636",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>record_type</th>\n",
-       "      <th>content</th>\n",
-       "      <th>metadata</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>fact</td>\n",
-       "      <td>Replacement shipment RMA-8842 for order ORD-74...</td>\n",
-       "      <td>{'$agent_memory': {'extraction_id': 'escalatio...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>fact</td>\n",
-       "      <td>A follow-up commitment to provide a status upd...</td>\n",
-       "      <td>{'$agent_memory': {'extraction_id': 'follow_up...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  record_type                                            content  \\\n",
-       "0        fact  Replacement shipment RMA-8842 for order ORD-74...   \n",
-       "1        fact  A follow-up commitment to provide a status upd...   \n",
-       "\n",
-       "                                            metadata  \n",
-       "0  {'$agent_memory': {'extraction_id': 'escalatio...  \n",
-       "1  {'$agent_memory': {'extraction_id': 'follow_up...  "
+      "cell_type": "markdown",
+      "id": "8dd214ef",
+      "metadata": {},
+      "source": [
+        "## What This Notebook Demonstrates\n",
+        "\n",
+        "| Area | What you will run | Why it matters |\n",
+        "|---|---|---|\n",
+        "| FreeSQL connection | Connect to a FreeSQL Oracle Database schema and verify table permissions | The notebook uses a lightweight hosted Oracle Database setup while still exercising real database-backed memory storage |\n",
+        "| Support policy use case | Process a customer-support conversation with order IDs, return requests, delivery issues, escalation commitments, and preferences | The use case gives the extractor clear domain priorities for what should become durable memory |\n",
+        "| Baseline vs custom extraction | Compare general extraction with support-specific extraction instructions | The comparison shows how custom instructions refine memory formation for a specific workflow |\n",
+        "| Thread-level control | Override, update, and clear extraction instructions for one support workflow | Different threads can use different memory policies without changing the global client configuration |\n",
+        "| Tool metadata | Preserve tool-confirmed support facts and inherit shared tool/workflow metadata | Tool tags such as `tool:order_status` make extracted memories easier to govern and retrieve later |\n",
+        "| Scoped retrieval checks | Inspect extracted records and search with metadata filters | Memory should be useful, searchable, and controlled by tenant, source, tag, and workflow |\n"
       ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "escalation_results = list_extracted_records(custom_store, escalation_thread.thread_id)\n",
-    "\n",
-    "pd.DataFrame(\n",
-    "    escalation_results,\n",
-    "    columns=[\"record_type\", \"content\", \"metadata\"],\n",
-    ")[[\"record_type\", \"content\", \"metadata\"]]\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ddd53865",
-   "metadata": {},
-   "source": [
-    "## Update and Clear Thread-Level Instructions\n",
-    "\n",
-    "`update_thread()` persists runtime configuration changes. Passing a partial\n",
-    "`MemoryExtractionConfig` updates only the provided fields. Passing\n",
-    "`memory_extraction_custom_instructions=None` clears the stored override.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "8dcf0d3a",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Thread-level extraction instructions updated and cleared: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "updated_escalation_thread = custom_memory.update_thread(\n",
-    "    escalation_thread.thread_id,\n",
-    "    memory_extraction_config=MemoryExtractionConfig(\n",
-    "        memory_extraction_custom_instructions=(\n",
-    "            \"Extract only shipment escalation commitments and customer-facing follow-up deadlines.\"\n",
-    "        )\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "cleared_escalation_thread = custom_memory.update_thread(\n",
-    "    escalation_thread.thread_id,\n",
-    "    memory_extraction_config=MemoryExtractionConfig(\n",
-    "        memory_extraction_custom_instructions=None\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "print(\"Thread-level extraction instructions updated and cleared: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ee20e1ce",
-   "metadata": {},
-   "source": [
-    "## Add Tool-Result Metadata to a Support Thread\n",
-    "\n",
-    "Richeek's feedback also called out tool usage extraction as a useful custom extraction scenario. In a real support agent, reliable operational facts often come from tools: order status, shipment status, return authorization, entitlement checks, or case-management systems.\n",
-    "\n",
-    "This section represents a tool result as an assistant message and attaches shared workflow metadata to the message batch. The custom extraction policy preserves the tool-confirmed business fact, while metadata inheritance adds tags such as `tool:order_status` to the extracted memory.\n",
-    "\n",
-    "That gives the application two useful controls later:\n",
-    "\n",
-    "- the memory text captures the durable support fact;\n",
-    "- the metadata records where the fact came from and how it should be scoped.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "7ef5573b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tool-aware policy and metadata: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "TOOL_AWARE_EXTRACTION_INSTRUCTIONS = \"\"\"\n",
-    "Extract durable support facts from user, assistant, and tool-result messages.\n",
-    "When the conversation contains a tool-confirmed status, preserve the business fact\n",
-    "but do not copy raw payload wording unless it is needed for follow-up.\n",
-    "Keep exact order IDs, shipment status, escalation reason, and customer-facing commitment.\n",
-    "\"\"\".strip()\n",
-    "\n",
-    "tool_metadata = {\n",
-    "    \"tenant\": \"acme\",\n",
-    "    \"source\": \"support-copilot\",\n",
-    "    \"tags\": [\"support\", \"tool:order_status\", \"replacement\"],\n",
-    "}\n",
-    "\n",
-    "print(\"Tool-aware policy and metadata: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d2fbcbc0",
-   "metadata": {},
-   "source": [
-    "### Run a Tool-Aware Thread\n",
-    "\n",
-    "The metadata is shared across the message batch so the selected metadata keys can be inherited safely by\n",
-    "extracted memories.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "936316f3",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tool-aware extraction thread: READY\n"
-     ]
-    }
-   ],
-   "source": [
-    "tool_thread = custom_memory.create_thread(\n",
-    "    thread_id=f\"tool_support_{RUN_ID}\",\n",
-    "    user_id=USER_ID,\n",
-    "    agent_id=AGENT_ID,\n",
-    "    memory_extraction_config=MemoryExtractionConfig(\n",
-    "        memory_extraction_frequency=1,\n",
-    "        enable_context_summary=False,\n",
-    "        memory_extraction_custom_instructions=TOOL_AWARE_EXTRACTION_INSTRUCTIONS,\n",
-    "        memory_extraction_inherit_message_metadata=[\"tenant\", \"source\", \"tags\"],\n",
-    "    ),\n",
-    ")\n",
-    "\n",
-    "await tool_thread.add_messages_async(\n",
-    "    [\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": \"Can you check the replacement status for order ORD-7421?\",\n",
-    "        },\n",
-    "        {\n",
-    "            \"role\": \"assistant\",\n",
-    "            \"content\": (\n",
-    "                \"Tool result from order_status: replacement shipment RMA-8842 for order \"\n",
-    "                \"ORD-7421 is delayed because the hinge part is backordered. Escalate if \"\n",
-    "                \"it does not ship by Friday.\"\n",
-    "            ),\n",
-    "        },\n",
-    "    ],\n",
-    "    metadata=tool_metadata,\n",
-    ")\n",
-    "await tool_thread.wait_for_memory_extraction_async()\n",
-    "\n",
-    "print(\"Tool-aware extraction thread: READY\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0d384e3b",
-   "metadata": {},
-   "source": [
-    "## Inspect Tool-Aware Memories\n",
-    "\n",
-    "Before applying metadata filters, inspect the memories extracted from the tool-aware support thread.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "1125035e",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>record_type</th>\n",
-       "      <th>content</th>\n",
-       "      <th>metadata</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>fact</td>\n",
-       "      <td>Replacement shipment RMA-8842 for order ORD-74...</td>\n",
-       "      <td>{'tenant': 'acme', 'source': 'support-copilot'...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>guideline</td>\n",
-       "      <td>Escalate the order status if the replacement s...</td>\n",
-       "      <td>{'tenant': 'acme', 'source': 'support-copilot'...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  record_type                                            content  \\\n",
-       "0        fact  Replacement shipment RMA-8842 for order ORD-74...   \n",
-       "1   guideline  Escalate the order status if the replacement s...   \n",
-       "\n",
-       "                                            metadata  \n",
-       "0  {'tenant': 'acme', 'source': 'support-copilot'...  \n",
-       "1  {'tenant': 'acme', 'source': 'support-copilot'...  "
+      "cell_type": "markdown",
+      "id": "4a92e9f7",
+      "metadata": {},
+      "source": [
+        "## Conceptual Flow\n",
+        "\n",
+        "The use case starts with one support conversation and sends it through two extraction paths. The baseline path shows the general behavior. The custom path adds a support-specific memory policy that describes durable support facts and exclusions.\n",
+        "\n",
+        "| Stage | Baseline path | Custom extraction path |\n",
+        "|---|---|---|\n",
+        "| Input | Same support conversation | Same support conversation plus support policy and metadata |\n",
+        "| Extraction behavior | General extraction baseline | Support-specific policy for durable facts and exclusions |\n",
+        "| Memory output | Baseline memories | Support memories: orders, returns, preferences, escalations, and tool-confirmed facts |\n",
+        "| Storage | Oracle Database records and metadata | Oracle Database records and inherited workflow metadata |\n",
+        "| Later use | General inspection and search | Scoped retrieval for reusable agent memory context |\n",
+        "\n",
+        "In short:\n",
+        "\n",
+        "```text\n",
+        "Support conversation\n",
+        "        |\n",
+        "        +--> Baseline extraction --> Baseline memories\n",
+        "        |\n",
+        "        +--> Custom support policy + workflow metadata\n",
+        "                 |\n",
+        "                 +--> Support memories: orders, returns, preferences, escalations\n",
+        "                          |\n",
+        "                          +--> Oracle Database records + metadata\n",
+        "                                   |\n",
+        "                                   +--> Scoped retrieval for future agent context\n",
+        "```\n"
       ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tool_stored_rows = list_extracted_records(custom_store, tool_thread.thread_id)\n",
-    "\n",
-    "pd.DataFrame(\n",
-    "    tool_stored_rows,\n",
-    "    columns=[\"record_type\", \"content\", \"metadata\"],\n",
-    ")[[\"record_type\", \"content\", \"metadata\"]]\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5e648687",
-   "metadata": {},
-   "source": [
-    "## Search Extracted Memories by Tool Metadata\n",
-    "\n",
-    "After tool-aware extraction, metadata filters let the application retrieve memories that belong to a selected support workflow. This is the governance side of custom extraction: the memory can be useful while still being scoped by tenant, source, and tool tag.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "6fdafa47",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tool_filtered_results = await tool_thread.search_async(\n",
-    "    \"replacement shipment delayed backordered hinge escalate\",\n",
-    "    max_results=5,\n",
-    "    exact_thread_match=True,\n",
-    "    record_types=[\"memory\", \"fact\", \"preference\", \"guideline\"],\n",
-    "    metadata_filter={\n",
-    "        \"tenant\": \"acme\",\n",
-    "        \"source\": \"support-copilot\",\n",
-    "        \"tags\": [\"support\", \"tool:order_status\", \"replacement\"],\n",
-    "    },\n",
-    ")\n",
-    "\n",
-    "tool_filtered_rows = [\n",
-    "    {\n",
-    "        \"record_type\": result.record.record_type,\n",
-    "        \"content\": result.content,\n",
-    "        \"metadata\": result.record.metadata,\n",
-    "    }\n",
-    "    for result in tool_filtered_results\n",
-    "]\n",
-    "\n",
-    "if tool_filtered_rows:\n",
-    "    pd.DataFrame(tool_filtered_rows)\n",
-    "else:\n",
-    "    pd.DataFrame(\n",
-    "        [{\"status\": \"No matching memories found. Re-run the tool-aware extraction cell before searching.\"}]\n",
-    "    )\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f04eba3c",
-   "metadata": {},
-   "source": [
-    "### Array Membership Filter Variant\n",
-    "\n",
-    "When metadata values are arrays, exact list matching is usually too strict. Array operators\n",
-    "such as `$array_contains`, `$array_contains_any`, and `$not` express workflow filters more\n",
-    "directly.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "ab36cb54",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tool_membership_results = await tool_thread.search_async(\n",
-    "    \"order replacement status\",\n",
-    "    max_results=5,\n",
-    "    exact_thread_match=True,\n",
-    "    record_types=[\"memory\", \"fact\", \"preference\", \"guideline\"],\n",
-    "    metadata_filter={\n",
-    "        \"tenant\": \"acme\",\n",
-    "        \"tags\": {\n",
-    "            \"$array_contains\": \"tool:order_status\",\n",
-    "            \"$array_contains_any\": [\"replacement\", \"support\"],\n",
-    "            \"$not\": {\"$array_contains\": \"returns\"},\n",
-    "        },\n",
-    "    },\n",
-    ")\n",
-    "\n",
-    "membership_rows = [\n",
-    "    {\n",
-    "        \"record_type\": result.record.record_type,\n",
-    "        \"content\": result.content,\n",
-    "        \"metadata\": result.record.metadata,\n",
-    "    }\n",
-    "    for result in tool_membership_results\n",
-    "]\n",
-    "\n",
-    "if membership_rows:\n",
-    "    pd.DataFrame(membership_rows)\n",
-    "else:\n",
-    "    pd.DataFrame(\n",
-    "        [{\"status\": \"No matching memories found for the array membership filter.\"}]\n",
-    "    )\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ee9509ef",
-   "metadata": {},
-   "source": [
-    "# Part 5 - Production Notes and Cleanup\n",
-    "\n",
-    "The workflow is intentionally small, but the same patterns map to production. In enterprise agents, memory extraction should reflect workflow priorities, privacy boundaries, and domain-specific facts instead of summarizing everything the user said.\n",
-    "\n",
-    "This matters because better memory policy can lead to:\n",
-    "\n",
-    "- fewer noisy memories;\n",
-    "- more consistent agent behavior across sessions;\n",
-    "- better retrieval because durable facts are easier to search and scope;\n",
-    "- stronger compliance posture because sensitive or temporary details are less likely to become durable memory;\n",
-    "- clearer ownership of what the application considers useful memory.\n",
-    "\n",
-    "Operationally, production applications should also:\n",
-    "\n",
-    "- keep authentication and authorization in the surrounding application;\n",
-    "- scope every memory operation by user, agent, thread, and metadata;\n",
-    "- treat custom extraction as policy guidance, not a hard redaction guarantee;\n",
-    "- avoid sending secrets or unnecessary sensitive content into memory ingestion;\n",
-    "- monitor extraction failures and queue pressure when using background extraction;\n",
-    "- use TTL and delete APIs for lifecycle control;\n",
-    "- configure scheduler-job privileges when administrators want expired records to be physically purged automatically.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8f18ee19",
-   "metadata": {},
-   "source": [
-    "## Cleanup and Shutdown\n",
-    "\n",
-    "The cleanup step removes the run-scoped example user and then closes application-owned resources.\n",
-    "\n",
-    "The order matters:\n",
-    "\n",
-    "1. delete the example memory records created by this run;\n",
-    "2. close the Oracle AI Agent Memory clients so no more memory operations use the pool;\n",
-    "3. close the Oracle Database pool last.\n",
-    "\n",
-    "Keeping this at the end makes repeated notebook runs easier and avoids leaving unnecessary example data in shared development schemas.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "ab4fa6e4",
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cleanup and shutdown: READY\n"
-     ]
+      "cell_type": "markdown",
+      "id": "2cd7cb27",
+      "metadata": {},
+      "source": [
+        "# Part 1 - Setup and Database Connection\n",
+        "\n",
+        "This section prepares a clean runtime:\n",
+        "\n",
+        "1. install the required Python packages;\n",
+        "2. choose an Oracle Database connection, including FreeSQL for a quick hosted schema;\n",
+        "3. configure the LLM and embedding route used by the full example.\n",
+        "\n",
+        "FreeSQL is useful when you want a fast Oracle Database connection without running a local container. For a\n",
+        "fully self-contained local run, you can also use Oracle Database Free in Docker.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "027a6aac",
+      "metadata": {},
+      "source": [
+        "## Install the Python Packages\n",
+        "\n",
+        "Install the package from PyPI. The `[litellm]` extra lets Oracle AI Agent Memory call configured chat and\n",
+        "embedding providers through one interface. `oracledb` is the Oracle Database driver, `pandas` is used to\n",
+        "display results, and `python-dotenv` is a local-development convenience for loading environment values.\n",
+        "\n",
+        "Run this once in a clean environment. A dedicated virtual environment is recommended so the database driver,\n",
+        "LLM dependencies, and memory package can be upgraded and tested together.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "2ce80e4a",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Python packages: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "import sys\n",
+        "from importlib.metadata import version\n",
+        "\n",
+        "from IPython.utils.capture import capture_output\n",
+        "\n",
+        "\n",
+        "assert (3, 10) <= sys.version_info[:2] <= (3, 13), (\n",
+        "    f\"Python 3.10-3.13 is required; found {sys.version.split()[0]}\"\n",
+        ")\n",
+        "\n",
+        "with capture_output():\n",
+        "    get_ipython().run_line_magic(\n",
+        "        \"pip\",\n",
+        "        \"install --upgrade oracleagentmemory[litellm]==26.6.0 oracledb pandas python-dotenv --quiet\",\n",
+        "    )\n",
+        "\n",
+        "package_version = version(\"oracleagentmemory\")\n",
+        "assert package_version == \"26.6.0\", (\n",
+        "    f\"Oracle AI Agent Memory 26.6.0 is required; found {package_version}\"\n",
+        ")\n",
+        "\n",
+        "print(\"Python packages: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0e857c2d",
+      "metadata": {},
+      "source": [
+        "## Option A - FreeSQL Connection Setup\n",
+        "\n",
+        "FreeSQL gives developers a quick Oracle Database schema at [freesql.com](https://freesql.com). After signing in, open **Connect to the Database**, choose **Python**, and copy the username, generated password, and DSN.\n",
+        "\n",
+        "Set these values as environment variables before running the notebook:\n",
+        "\n",
+        "```text\n",
+        "DB_USER=<FreeSQL schema username>\n",
+        "DB_PASSWORD=<generated FreeSQL schema password>\n",
+        "DB_CONNECT_STRING=tcps://db.freesql.com:2484/<FreeSQL service name>\n",
+        "# DB_DSN is also accepted as an alias for DB_CONNECT_STRING.\n",
+        "```\n",
+        "\n",
+        "The next setup cell opens a real Oracle Database connection and verifies that the schema can create and remove a small table.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### FreeSQL Connection Guide\n",
+        "\n",
+        "Use this path when you want a hosted Oracle Database schema without setting up a local database.\n",
+        "\n",
+        "<details>\n",
+        "<summary><strong>FreeSQL setup steps</strong></summary>\n",
+        "\n",
+        "1. Sign in to [FreeSQL](https://freesql.com).\n",
+        "2. Open **Connect to the Database**.\n",
+        "3. Choose **Python**.\n",
+        "4. Copy the generated username, password, and DSN/connect descriptor.\n",
+        "5. Add them to your private `.env` file:\n",
+        "\n",
+        "```env\n",
+        "DB_USER=<freesql-user>\n",
+        "DB_PASSWORD=<freesql-password>\n",
+        "DB_CONNECT_STRING=<freesql-python-dsn>\n",
+        "MODEL_PROVIDER_API_KEY=<model-provider-api-key>\n",
+        "MEMORY_LLM_MODEL=gpt-4o-mini\n",
+        "EMBED_BACKEND=provider\n",
+        "```\n",
+        "\n",
+        "</details>\n",
+        "\n",
+        "**Setup flow**\n",
+        "\n",
+        "`FreeSQL credentials` -> `python-oracledb connection` -> `table-permission check` -> `Agent Memory store` -> `custom extraction workflow`\n",
+        "\n",
+        "The connection preflight below confirms that the database connection works before the notebook creates the Oracle AI Agent Memory store. For FreeSQL, the notebook uses the lightweight provider/keyword retrieval route so the custom extraction workflow can focus on database-backed memory records, metadata, and scoped retrieval.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "91f28e1a",
+      "metadata": {},
+      "source": [
+        "## Optional Fallback - Standalone Oracle Database Setup with Docker\n",
+        "\n",
+        "Use Oracle Database Free in Docker when you want a reproducible local database for the full example.\n",
+        "\n",
+        "```bash\n",
+        "docker pull gvenzl/oracle-free:23.26.2\n",
+        "docker volume create oracle-free-data\n",
+        "\n",
+        "docker run -d \\\n",
+        "  --name oracle-ai-memory-example \\\n",
+        "  -p 1522:1521 \\\n",
+        "  -e ORACLE_PASSWORD=\"<admin-password>\" \\\n",
+        "  -e APP_USER=\"<app-user>\" \\\n",
+        "  -e APP_USER_PASSWORD=\"<app-password>\" \\\n",
+        "  -v oracle-free-data:/opt/oracle/oradata \\\n",
+        "  gvenzl/oracle-free:23.26.2\n",
+        "\n",
+        "docker logs -f oracle-ai-memory-example\n",
+        "```\n",
+        "\n",
+        "Then configure the active connection:\n",
+        "\n",
+        "```text\n",
+        "DB_USER=<app-user>\n",
+        "DB_PASSWORD=<app-password>\n",
+        "DB_CONNECT_STRING=localhost:1522/FREEPDB1\n",
+        "```\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "23c44407",
+      "metadata": {},
+      "source": [
+        "## Runtime Configuration\n",
+        "\n",
+        "The notebook needs one Oracle Database connection and one model provider key for memory extraction:\n",
+        "\n",
+        "| Variable | Purpose |\n",
+        "|---|---|\n",
+        "| `DB_USER` | Oracle Database schema user |\n",
+        "| `DB_PASSWORD` | Password for the schema user |\n",
+        "| `DB_CONNECT_STRING` | Oracle Database connect string or descriptor |\n",
+        "| `MODEL_PROVIDER_API_KEY` | Provider key used by the configured memory extraction LLM |\n",
+        "| `MEMORY_LLM_MODEL` | Chat model used for memory extraction |\n",
+        "\n",
+        "For retrieval, use one of these routes:\n",
+        "\n",
+        "| Route | When to use it | Required variables |\n",
+        "|---|---|---|\n",
+        "| `EMBED_BACKEND=provider` | Default FreeSQL-friendly route for this custom extraction notebook | none beyond the model provider key |\n",
+        "| `EMBED_BACKEND=indb` | Oracle-native route when a database-resident embedding model is available | `DB_EMBED_MODEL`, `DB_EMBED_DIM` |\n",
+        "\n",
+        "The default route keeps retrieval lightweight so the notebook can focus on custom extraction behavior. In an Oracle AI Database environment with a visible embedding model, switch to `EMBED_BACKEND=indb` to use `OracleDBEmbedder`.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8e9fdd79",
+      "metadata": {},
+      "source": [
+        "## Load Local Environment Values\n",
+        "\n",
+        "This cell loads local environment values when present. Public runners can set the same values directly as\n",
+        "environment variables.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "87c51737",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Runtime configuration loader: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "from dotenv import load_dotenv\n",
+        "\n",
+        "\n",
+        "load_dotenv(Path.cwd() / \".env\")\n",
+        "\n",
+        "print(\"Runtime configuration loader: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d7e6c632",
+      "metadata": {},
+      "source": [
+        "## Read and Validate Configuration\n",
+        "\n",
+        "The notebook validates only whether required values exist. It does not print usernames, passwords, DSNs,\n",
+        "schema names, database versions, or local paths.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "7d7a7f1d",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Required configuration: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "import os\n",
+        "\n",
+        "import pandas as pd\n",
+        "\n",
+        "\n",
+        "CONFIG = {\n",
+        "    \"DB_USER\": os.getenv(\"DB_USER\") or os.getenv(\"ORACLE_USER\"),\n",
+        "    \"DB_PASSWORD\": os.getenv(\"DB_PASSWORD\") or os.getenv(\"ORACLE_PASSWORD\"),\n",
+        "    \"DB_CONNECT_STRING\": os.getenv(\"DB_CONNECT_STRING\") or os.getenv(\"DB_DSN\") or os.getenv(\"ORACLE_DSN\"),\n",
+        "    \"MODEL_PROVIDER_API_KEY\": os.getenv(\"MODEL_PROVIDER_API_KEY\") or os.getenv(\"MEMORY_LLM_API_KEY\"),\n",
+        "    \"MEMORY_LLM_API_BASE\": os.getenv(\"MEMORY_LLM_API_BASE\"),\n",
+        "    \"MEMORY_LLM_API_TYPE\": os.getenv(\"MEMORY_LLM_API_TYPE\", \"chat_completions\"),\n",
+        "    \"MEMORY_LLM_MODEL\": os.getenv(\"MEMORY_LLM_MODEL\") or \"gpt-4o-mini\",\n",
+        "    \"EMBED_BACKEND\": os.getenv(\"EMBED_BACKEND\", \"provider\").lower(),\n",
+        "    \"EMBED_MODEL\": os.getenv(\"EMBED_MODEL\", \"text-embedding-3-small\"),\n",
+        "    \"EMBED_DIM\": int(os.getenv(\"EMBED_DIM\", \"1536\")),\n",
+        "    \"DB_EMBED_MODEL\": os.getenv(\"DB_EMBED_MODEL\") or os.getenv(\"ORACLE_DB_EMBEDDING_MODEL\"),\n",
+        "    \"DB_EMBED_DIM\": os.getenv(\"DB_EMBED_DIM\") or os.getenv(\"ORACLE_DB_EMBEDDING_DIMENSION\"),\n",
+        "    \"DB_EMBED_INPUT\": os.getenv(\"DB_EMBED_INPUT\", \"DATA\"),\n",
+        "}\n",
+        "\n",
+        "\n",
+        "required = {\n",
+        "    \"DB_USER\": \"DB_USER or ORACLE_USER\",\n",
+        "    \"DB_PASSWORD\": \"DB_PASSWORD or ORACLE_PASSWORD\",\n",
+        "    \"DB_CONNECT_STRING\": \"DB_CONNECT_STRING, DB_DSN, or ORACLE_DSN\",\n",
+        "    \"MODEL_PROVIDER_API_KEY\": \"MODEL_PROVIDER_API_KEY or MEMORY_LLM_API_KEY\",\n",
+        "}\n",
+        "missing = [label for key, label in required.items() if not CONFIG.get(key)]\n",
+        "if missing:\n",
+        "    raise RuntimeError(\n",
+        "        \"Missing required environment values: \"\n",
+        "        + \", \".join(missing)\n",
+        "        + \". Add them before running the notebook.\"\n",
+        "    )\n",
+        "\n",
+        "print(\"Required configuration: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6632f597",
+      "metadata": {},
+      "source": [
+        "## Create and Verify the Oracle Database Connection Pool\n",
+        "\n",
+        "This cell creates the Oracle Database connection pool used by the notebook. When the connection string points to FreeSQL, it also verifies the FreeSQL setup requested for this content.\n",
+        "\n",
+        "A pool is used instead of a single raw connection because Oracle AI Agent Memory can perform several kinds of database work during a realistic application flow: message writes, memory extraction, memory inspection, and retrieval. Even in a notebook, using a pool mirrors the application pattern more closely.\n",
+        "\n",
+        "The check intentionally prints only readiness status. It does not display usernames, schema names, DSNs, passwords, database versions, or local paths.\n",
+        "\n",
+        "It verifies:\n",
+        "\n",
+        "- Python can connect to the configured Oracle Database service;\n",
+        "- a simple `SELECT 1 FROM dual` query succeeds;\n",
+        "- the schema can create, insert into, read from, and drop a small table.\n",
+        "\n",
+        "The table-permission check matters because Oracle AI Agent Memory creates and manages its own database objects during schema setup.\n",
+        "\n",
+        "The connection also sets a Developer Hub program identifier before the pool is created, so usage can be recognized in Oracle Developer Hub telemetry.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "f18f359d",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "FreeSQL connection and table permissions: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "import oracledb\n",
+        "from uuid import uuid4\n",
+        "\n",
+        "\n",
+        "oracledb.defaults.program = \"devrel-developerhub-custom-memory-extraction-agent-memory\"\n",
+        "\n",
+        "\n",
+        "db_pool = oracledb.create_pool(\n",
+        "    user=CONFIG[\"DB_USER\"],\n",
+        "    password=CONFIG[\"DB_PASSWORD\"],\n",
+        "    dsn=CONFIG[\"DB_CONNECT_STRING\"],\n",
+        "    min=1,\n",
+        "    max=4,\n",
+        "    increment=1,\n",
+        ")\n",
+        "\n",
+        "permission_check_table = f\"OAM_FREESQL_CHECK_{uuid4().hex[:8].upper()}\"\n",
+        "\n",
+        "try:\n",
+        "    with db_pool.acquire() as connection:\n",
+        "        with connection.cursor() as cursor:\n",
+        "            cursor.execute(\"SELECT 1 FROM dual\").fetchone()\n",
+        "            cursor.execute(\n",
+        "                f\"\"\"\n",
+        "                CREATE TABLE {permission_check_table} (\n",
+        "                    id NUMBER PRIMARY KEY,\n",
+        "                    note VARCHAR2(100)\n",
+        "                )\n",
+        "                \"\"\"\n",
+        "            )\n",
+        "            cursor.execute(\n",
+        "                f\"INSERT INTO {permission_check_table} (id, note) VALUES (:id, :note)\",\n",
+        "                id=1,\n",
+        "                note=\"table permission check\",\n",
+        "            )\n",
+        "            count = cursor.execute(\n",
+        "                f\"SELECT COUNT(*) FROM {permission_check_table}\"\n",
+        "            ).fetchone()[0]\n",
+        "            if count != 1:\n",
+        "                raise RuntimeError(\"Table permission check returned an unexpected row count.\")\n",
+        "        connection.commit()\n",
+        "finally:\n",
+        "    try:\n",
+        "        with db_pool.acquire() as cleanup_connection:\n",
+        "            with cleanup_connection.cursor() as cursor:\n",
+        "                cursor.execute(f\"DROP TABLE {permission_check_table} PURGE\")\n",
+        "            cleanup_connection.commit()\n",
+        "    except oracledb.Error:\n",
+        "        pass\n",
+        "\n",
+        "print(\"FreeSQL connection and table permissions: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9f99c799",
+      "metadata": {},
+      "source": [
+        "## Choose the Retrieval Route\n",
+        "\n",
+        "This notebook focuses on custom memory extraction, so the default FreeSQL path uses keyword retrieval. That keeps the workflow lightweight while still using Oracle AI Agent Memory for database-backed storage, extraction, thread control, metadata, and scoped search.\n",
+        "\n",
+        "For Oracle AI Database environments where a database-resident embedding model is available, switch to `EMBED_BACKEND=indb` to use `OracleDBEmbedder` and hybrid retrieval with the same memory APIs.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "fcd2c59b",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Retrieval route: portable keyword search\n"
+          ]
+        }
+      ],
+      "source": [
+        "from oracleagentmemory.core import SearchIndexSyncMode, SearchStrategy\n",
+        "from oracleagentmemory.core.embedders import Embedder, OracleDBEmbedder\n",
+        "\n",
+        "\n",
+        "EMBED_BACKEND = CONFIG[\"EMBED_BACKEND\"]\n",
+        "\n",
+        "if EMBED_BACKEND == \"indb\":\n",
+        "    missing_indb = [\n",
+        "        name\n",
+        "        for name in [\"DB_EMBED_MODEL\", \"DB_EMBED_DIM\"]\n",
+        "        if not CONFIG.get(name) or str(CONFIG.get(name)).startswith(\"<\")\n",
+        "    ]\n",
+        "    if missing_indb:\n",
+        "        raise RuntimeError(\n",
+        "            \"EMBED_BACKEND=indb requires: \"\n",
+        "            + \", \".join(missing_indb)\n",
+        "            + \". Use EMBED_BACKEND=provider for a portable run, or configure a visible database embedding model.\"\n",
+        "        )\n",
+        "\n",
+        "    embedder = OracleDBEmbedder(\n",
+        "        connection=db_pool,\n",
+        "        model=CONFIG[\"DB_EMBED_MODEL\"],\n",
+        "        input_name=CONFIG[\"DB_EMBED_INPUT\"],\n",
+        "        embedding_dimension=int(CONFIG[\"DB_EMBED_DIM\"]),\n",
+        "        max_input_tokens=512,\n",
+        "        normalize=True,\n",
+        "        batch_size=16,\n",
+        "    )\n",
+        "    SEARCH_STRATEGY = SearchStrategy.HYBRID\n",
+        "    SEARCH_INDEX_SYNC = SearchIndexSyncMode.ON_COMMIT\n",
+        "    VECTOR_DIM = None\n",
+        "    print(\"Embedding route: OracleDBEmbedder\")\n",
+        "\n",
+        "elif EMBED_BACKEND == \"provider\":\n",
+        "    # The portable FreeSQL path keeps retrieval keyword-based so the notebook\n",
+        "    # can run without creating database vector indexes. The LLM provider is\n",
+        "    # still used for memory extraction.\n",
+        "    embedder = None\n",
+        "    SEARCH_STRATEGY = SearchStrategy.KEYWORD\n",
+        "    SEARCH_INDEX_SYNC = None\n",
+        "    VECTOR_DIM = None\n",
+        "    print(\"Retrieval route: portable keyword search\")\n",
+        "\n",
+        "else:\n",
+        "    raise RuntimeError(\"EMBED_BACKEND must be either 'indb' or 'provider'.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "20e45a73",
+      "metadata": {},
+      "source": [
+        "## Configure the Memory Extraction LLM\n",
+        "\n",
+        "The LLM is used by Oracle AI Agent Memory to transform raw conversation messages into durable memory records. Retrieval configuration is handled separately, so the notebook can demonstrate the extraction policy independently from the retrieval backend.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "eda4fa11",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Memory extraction LLM: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "from oracleagentmemory.core.llms import Llm, LlmApiType\n",
+        "\n",
+        "\n",
+        "llm_kwargs = {\n",
+        "    \"model\": CONFIG[\"MEMORY_LLM_MODEL\"],\n",
+        "    \"api_key\": CONFIG[\"MODEL_PROVIDER_API_KEY\"],\n",
+        "    \"temperature\": 0,\n",
+        "    \"max_tokens\": 2_000,\n",
+        "}\n",
+        "if CONFIG[\"MEMORY_LLM_API_BASE\"]:\n",
+        "    llm_kwargs[\"api_base\"] = CONFIG[\"MEMORY_LLM_API_BASE\"]\n",
+        "if CONFIG[\"MEMORY_LLM_API_TYPE\"] == \"responses\":\n",
+        "    llm_kwargs[\"api_type\"] = LlmApiType.RESPONSES\n",
+        "\n",
+        "memory_llm = Llm(**llm_kwargs)\n",
+        "\n",
+        "print(\"Memory extraction LLM: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "259ae8e1",
+      "metadata": {},
+      "source": [
+        "# Part 2 - Extraction Policy and Memory Clients\n",
+        "\n",
+        "This section defines the support-specific extraction policy and creates two memory clients over the same database-backed store:\n",
+        "\n",
+        "- a baseline client that uses the package's general extraction behavior;\n",
+        "- a custom client that adds support-specific extraction instructions.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "09aab796",
+      "metadata": {},
+      "source": [
+        "## Define Domain-Specific Extraction Instructions\n",
+        "\n",
+        "Custom extraction instructions are appended to the built-in extraction prompt. In this example, the instructions define the support team's memory policy: preserve durable business facts and exact identifiers, and avoid temporary or sensitive details.\n",
+        "\n",
+        "Good instructions describe business intent and exclusions. They should guide memory formation without depending on provider-specific output formatting.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "b1e70f25",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Support extraction policy: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "SUPPORT_EXTRACTION_INSTRUCTIONS = \"\"\"\n",
+        "Extract only durable customer-support memory that can help future support interactions.\n",
+        "\n",
+        "Preserve:\n",
+        "- confirmed order identifiers, return identifiers, case identifiers, and return requests;\n",
+        "- delivery problems, product defects, replacement commitments, and escalation reasons;\n",
+        "- stable customer preferences that should influence future interactions;\n",
+        "- tool-derived support facts when the source message metadata identifies a tool result.\n",
+        "\n",
+        "Ignore:\n",
+        "- greetings, small talk, apologies, and temporary conversational wording;\n",
+        "- speculation or unconfirmed guesses;\n",
+        "- credentials, payment secrets, one-time verification codes, and unnecessary sensitive data.\n",
+        "\n",
+        "Prefer concise facts, preferences, or guidelines. Keep exact identifiers when they matter.\n",
+        "\"\"\".strip()\n",
+        "\n",
+        "print(\"Support extraction policy: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "08612057",
+      "metadata": {},
+      "source": [
+        "## Define Example Scope\n",
+        "\n",
+        "The run-specific IDs keep repeated notebook executions isolated from each other.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "a490da8c",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Example scope: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "from uuid import uuid4\n",
+        "\n",
+        "\n",
+        "RUN_ID = uuid4().hex[:8]\n",
+        "MEMORY_STORE_ID = \"CUST_EXTRACT\"\n",
+        "USER_ID = f\"customer_custom_extract_{RUN_ID}\"\n",
+        "AGENT_ID = f\"support_agent_{RUN_ID}\"\n",
+        "\n",
+        "print(\"Example scope: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "90d437c2",
+      "metadata": {},
+      "source": [
+        "## Create the Database Stores\n",
+        "\n",
+        "The helper below passes `search_index_sync` only when the selected search strategy supports it. This matters\n",
+        "because vector-only search does not use the text-search index sync setting.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "8de4f70e",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Database-backed memory stores: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "import contextlib\n",
+        "import io\n",
+        "import warnings\n",
+        "\n",
+        "from oracleagentmemory.core import OracleDBMemoryStore, SchemaPolicy\n",
+        "\n",
+        "\n",
+        "def build_store(schema_policy):\n",
+        "    store_kwargs = {\n",
+        "        \"pool\": db_pool,\n",
+        "        \"embedder\": embedder,\n",
+        "        \"memory_store_id\": MEMORY_STORE_ID,\n",
+        "        \"schema_policy\": schema_policy,\n",
+        "        \"search_strategy\": SEARCH_STRATEGY,\n",
+        "        \"vector_dim\": VECTOR_DIM,\n",
+        "    }\n",
+        "    if SEARCH_INDEX_SYNC is not None:\n",
+        "        store_kwargs[\"search_index_sync\"] = SEARCH_INDEX_SYNC\n",
+        "    return OracleDBMemoryStore(**store_kwargs)\n",
+        "\n",
+        "\n",
+        "suppressed_stderr = io.StringIO()\n",
+        "with warnings.catch_warnings():\n",
+        "    warnings.simplefilter(\"ignore\", category=UserWarning)\n",
+        "    with contextlib.redirect_stderr(suppressed_stderr):\n",
+        "        base_store = build_store(SchemaPolicy.CREATE_IF_NECESSARY)\n",
+        "        custom_store = build_store(SchemaPolicy.REQUIRE_EXISTING)\n",
+        "\n",
+        "print(\"Database-backed memory stores: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "dd3e5d69",
+      "metadata": {},
+      "source": [
+        "## Create Baseline and Custom Memory Clients\n",
+        "\n",
+        "The baseline client uses the general extraction behavior. The custom client uses the same database store and LLM, but adds support-specific extraction instructions through `MemoryExtractionConfig`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "c44ca6ca",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Default and custom memory clients: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "from oracleagentmemory.core import MemoryExtractionConfig, OracleAgentMemory\n",
+        "\n",
+        "\n",
+        "base_memory = OracleAgentMemory(\n",
+        "    store=base_store,\n",
+        "    llm=memory_llm,\n",
+        "    memory_extraction_config=MemoryExtractionConfig(\n",
+        "        memory_extraction_frequency=1,\n",
+        "        enable_context_summary=False,\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "custom_memory = OracleAgentMemory(\n",
+        "    store=custom_store,\n",
+        "    llm=memory_llm,\n",
+        "    memory_extraction_config=MemoryExtractionConfig(\n",
+        "        memory_extraction_frequency=1,\n",
+        "        enable_context_summary=False,\n",
+        "        memory_extraction_custom_instructions=SUPPORT_EXTRACTION_INSTRUCTIONS,\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "print(\"Default and custom memory clients: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b2effb03",
+      "metadata": {},
+      "source": [
+        "# Part 3 - Baseline vs Custom Extraction\n",
+        "\n",
+        "This is the core use-case section. The same support conversation is processed twice so the difference is easy to inspect:\n",
+        "\n",
+        "- **Baseline extraction** shows the general extraction behavior.\n",
+        "- **Custom extraction** adds a support memory policy for durable support facts, exact identifiers, and temporary or sensitive details that should be ignored.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "015ef234",
+      "metadata": {},
+      "source": [
+        "## Prepare the Support Conversation\n",
+        "\n",
+        "The conversation deliberately includes information with different memory lifecycles.\n",
+        "\n",
+        "Durable support facts:\n",
+        "\n",
+        "- order ID and damaged product detail;\n",
+        "- return request and replacement delivery intent;\n",
+        "- stable delivery preference;\n",
+        "- escalation condition.\n",
+        "\n",
+        "Short-lived or sensitive details:\n",
+        "\n",
+        "- greeting and conversational wording;\n",
+        "- temporary lobby code;\n",
+        "- anything that looks like a one-time or sensitive detail.\n",
+        "\n",
+        "This makes the use case practical: the custom policy is not trying to replace general extraction; it adds domain guidance for what this support workflow considers reusable memory.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "a1cb5abb",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Support conversation: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "SUPPORT_CONVERSATION = [\n",
+        "    {\n",
+        "        \"role\": \"user\",\n",
+        "        \"content\": (\n",
+        "            \"Hi! Order ORD-7421 arrived damaged. The left hinge is cracked, \"\n",
+        "            \"and I need a return request plus a replacement delivery. \"\n",
+        "            \"My temporary lobby code today is 4812, but please do not save that.\"\n",
+        "        ),\n",
+        "    },\n",
+        "    {\n",
+        "        \"role\": \"assistant\",\n",
+        "        \"content\": (\n",
+        "            \"I can help with order ORD-7421. I will start a return request and \"\n",
+        "            \"mark the damaged hinge as the replacement reason.\"\n",
+        "        ),\n",
+        "    },\n",
+        "    {\n",
+        "        \"role\": \"user\",\n",
+        "        \"content\": (\n",
+        "            \"For future deliveries, I prefer morning delivery windows. \"\n",
+        "            \"Please escalate if the replacement cannot ship this week.\"\n",
+        "        ),\n",
+        "    },\n",
+        "]\n",
+        "\n",
+        "print(\"Support conversation: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0bdee195",
+      "metadata": {},
+      "source": [
+        "## Run Baseline Extraction\n",
+        "\n",
+        "Baseline extraction provides a general-purpose comparison point. It can capture useful facts from the conversation, but it does not apply the support-specific policy defined above. This lets us compare the general behavior with a custom policy for durable support facts, exact identifiers, and temporary details that should be ignored.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "id": "26c3dd23",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Default extraction thread: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "default_thread = base_memory.create_thread(\n",
+        "    thread_id=f\"default_support_{RUN_ID}\",\n",
+        "    user_id=USER_ID,\n",
+        "    agent_id=AGENT_ID,\n",
+        ")\n",
+        "\n",
+        "await default_thread.add_messages_async(SUPPORT_CONVERSATION)\n",
+        "await default_thread.wait_for_memory_extraction_async()\n",
+        "\n",
+        "print(\"Default extraction thread: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "382b063a",
+      "metadata": {},
+      "source": [
+        "## Run Custom Support Extraction\n",
+        "\n",
+        "The same conversation is now processed with custom extraction instructions. These instructions add the support workflow policy: preserve durable facts such as order IDs, return requests, delivery preferences, and escalation commitments, while avoiding temporary or sensitive details.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "id": "65856227",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Custom extraction thread: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "custom_thread = custom_memory.create_thread(\n",
+        "    thread_id=f\"custom_support_{RUN_ID}\",\n",
+        "    user_id=USER_ID,\n",
+        "    agent_id=AGENT_ID,\n",
+        ")\n",
+        "\n",
+        "await custom_thread.add_messages_async(SUPPORT_CONVERSATION)\n",
+        "await custom_thread.wait_for_memory_extraction_async()\n",
+        "\n",
+        "print(\"Custom extraction thread: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "863fa9ce",
+      "metadata": {},
+      "source": [
+        "## Compare Extracted Memories\n",
+        "\n",
+        "First inspect the records created by the two extraction paths. This is the central comparison in the notebook:\n",
+        "\n",
+        "- **Baseline extraction** shows general memory behavior.\n",
+        "- **Custom extraction** shows support-specific memory behavior shaped by the extraction policy.\n",
+        "\n",
+        "The comparison should make the before/after difference easy to see. Look for whether the custom path preserves durable support facts more directly, such as order IDs, return or replacement details, delivery preferences, escalation commitments, and tool-confirmed support state.\n",
+        "\n",
+        "The other side of the comparison is equally important: temporary details, such as the lobby code, should not become durable memory.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "id": "b8294f43",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Memory inspection helpers: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "RECORD_TYPES_TO_INSPECT = [\"memory\", \"fact\", \"preference\", \"guideline\"]\n",
+        "\n",
+        "\n",
+        "def record_to_row(record):\n",
+        "    return {\n",
+        "        \"record_type\": record.record_type,\n",
+        "        \"content\": getattr(record, \"content\", None) or getattr(record, \"text\", None),\n",
+        "        \"metadata\": record.metadata,\n",
+        "    }\n",
+        "\n",
+        "\n",
+        "def list_extracted_records(store, thread_id):\n",
+        "    rows = []\n",
+        "    for record_type in RECORD_TYPES_TO_INSPECT:\n",
+        "        for record in store.list(record_type, thread_id=thread_id, limit=None):\n",
+        "            rows.append(record_to_row(record))\n",
+        "    return rows\n",
+        "\n",
+        "\n",
+        "async def search_thread_results(thread, queries, *, max_results=5):\n",
+        "    seen = {}\n",
+        "    for query in queries:\n",
+        "        for result in await thread.search_async(\n",
+        "            query,\n",
+        "            max_results=max_results,\n",
+        "            exact_thread_match=True,\n",
+        "            record_types=RECORD_TYPES_TO_INSPECT,\n",
+        "        ):\n",
+        "            record = result.record\n",
+        "            key = getattr(record, \"id\", None) or (record.record_type, result.content)\n",
+        "            seen[key] = {\n",
+        "                \"record_type\": record.record_type,\n",
+        "                \"content\": result.content,\n",
+        "                \"metadata\": record.metadata,\n",
+        "            }\n",
+        "    return list(seen.values())\n",
+        "\n",
+        "\n",
+        "print(\"Memory inspection helpers: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f86ae4bb",
+      "metadata": {},
+      "source": [
+        "### Inspect the Stored Memory Records\n",
+        "\n",
+        "The table below compares the records created by default extraction and by the custom support policy.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "id": "7ff9c7a8",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "default_memories = list_extracted_records(base_store, default_thread.thread_id)\n",
+        "custom_memories = list_extracted_records(custom_store, custom_thread.thread_id)\n",
+        "\n",
+        "comparison_columns = [\"extraction\", \"record_type\", \"content\", \"metadata\"]\n",
+        "comparison = pd.DataFrame(\n",
+        "    [{\"extraction\": \"Default\", **row} for row in default_memories]\n",
+        "    + [{\"extraction\": \"Custom support policy\", **row} for row in custom_memories],\n",
+        "    columns=comparison_columns,\n",
+        ")\n",
+        "\n",
+        "if comparison.empty:\n",
+        "    pd.DataFrame([{\"status\": \"No extracted memory records found. Check the extraction LLM configuration and rerun the extraction cells.\"}])\n",
+        "else:\n",
+        "    comparison[comparison_columns]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a76f1a37",
+      "metadata": {},
+      "source": [
+        "### Lightweight Quality Check\n",
+        "\n",
+        "This check is intentionally simple and readable. It does not grade the model or claim benchmark quality. It verifies the expected behavior for this support use case.\n",
+        "\n",
+        "Expected result:\n",
+        "\n",
+        "- the custom memory output keeps the order ID;\n",
+        "- it keeps return or replacement details;\n",
+        "- it keeps the stable delivery preference;\n",
+        "- it avoids saving temporary details such as the lobby code.\n",
+        "\n",
+        "These checks make the notebook easier to review because they turn the policy goal into concrete output expectations.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "id": "a3ed03af",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>extraction</th>\n",
+              "      <th>mentions_order_id</th>\n",
+              "      <th>mentions_return_or_replacement</th>\n",
+              "      <th>mentions_delivery_preference</th>\n",
+              "      <th>temporary_code_leaked</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Default</td>\n",
+              "      <td>True</td>\n",
+              "      <td>True</td>\n",
+              "      <td>True</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Custom support policy</td>\n",
+              "      <td>True</td>\n",
+              "      <td>True</td>\n",
+              "      <td>True</td>\n",
+              "      <td>False</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "              extraction  mentions_order_id  mentions_return_or_replacement  \\\n",
+              "0                Default               True                            True   \n",
+              "1  Custom support policy               True                            True   \n",
+              "\n",
+              "   mentions_delivery_preference  temporary_code_leaked  \n",
+              "0                          True                  False  \n",
+              "1                          True                  False  "
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "def score_memory_set(rows):\n",
+        "    text = \" \".join(str(row[\"content\"]).lower() for row in rows)\n",
+        "    return {\n",
+        "        \"mentions_order_id\": \"ord-7421\" in text or \"7421\" in text,\n",
+        "        \"mentions_return_or_replacement\": any(\n",
+        "            token in text for token in [\"return\", \"replacement\", \"replace\"]\n",
+        "        ),\n",
+        "        \"mentions_delivery_preference\": \"morning\" in text and \"delivery\" in text,\n",
+        "        \"temporary_code_leaked\": \"4812\" in text,\n",
+        "    }\n",
+        "\n",
+        "\n",
+        "quality = pd.DataFrame(\n",
+        "    [\n",
+        "        {\"extraction\": \"Default\", **score_memory_set(default_memories)},\n",
+        "        {\"extraction\": \"Custom support policy\", **score_memory_set(custom_memories)},\n",
+        "    ]\n",
+        ")\n",
+        "\n",
+        "quality\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "fd7542c9",
+      "metadata": {},
+      "source": [
+        "# Part 4 - Thread-Level Control and Tool Metadata\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "bb9c340c",
+      "metadata": {},
+      "source": [
+        "## Override Instructions for One Thread\n",
+        "\n",
+        "Client-level instructions are the default. A thread-level override is useful when one support conversation has\n",
+        "a narrower workflow, such as escalation handling, replacement tracking, or incident follow-up.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 17,
+      "id": "dc745954",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Escalation extraction policy: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "ESCALATION_EXTRACTION_INSTRUCTIONS = \"\"\"\n",
+        "Extract only durable escalation-support facts:\n",
+        "- escalation reasons;\n",
+        "- replacement shipment identifiers;\n",
+        "- customer-facing follow-up commitments;\n",
+        "- deadlines or status checks that should influence future support turns.\n",
+        "Ignore general delivery preferences and unrelated return-request details.\n",
+        "\"\"\".strip()\n",
+        "\n",
+        "print(\"Escalation extraction policy: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "76c82c18",
+      "metadata": {},
+      "source": [
+        "### Run an Escalation-Specific Thread\n",
+        "\n",
+        "This thread overrides the broader support policy with narrower escalation-specific instructions for one\n",
+        "conversation.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "id": "afa2a16b",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Escalation extraction thread: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "escalation_thread = custom_memory.create_thread(\n",
+        "    thread_id=f\"escalation_support_{RUN_ID}\",\n",
+        "    user_id=USER_ID,\n",
+        "    agent_id=AGENT_ID,\n",
+        "    memory_extraction_config=MemoryExtractionConfig(\n",
+        "        memory_extraction_frequency=1,\n",
+        "        enable_context_summary=False,\n",
+        "        memory_extraction_custom_instructions=ESCALATION_EXTRACTION_INSTRUCTIONS,\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "await escalation_thread.add_messages_async(\n",
+        "    [\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": (\n",
+        "                \"Replacement shipment RMA-8842 for order ORD-7421 still has not shipped. \"\n",
+        "                \"Please escalate because the customer needs a status update by Friday.\"\n",
+        "            ),\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"assistant\",\n",
+        "            \"content\": (\n",
+        "                \"I will escalate replacement shipment RMA-8842 and track the Friday follow-up commitment.\"\n",
+        "            ),\n",
+        "        },\n",
+        "    ]\n",
+        ")\n",
+        "await escalation_thread.wait_for_memory_extraction_async()\n",
+        "\n",
+        "print(\"Escalation extraction thread: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ac893ce9",
+      "metadata": {},
+      "source": [
+        "### Inspect Escalation Memories\n",
+        "\n",
+        "Inspect the records extracted from the overridden thread. The expected output is narrower than the broader support policy because this thread focuses on escalation and shipment follow-up.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "id": "1534c636",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>record_type</th>\n",
+              "      <th>content</th>\n",
+              "      <th>metadata</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>fact</td>\n",
+              "      <td>Replacement shipment RMA-8842 for order ORD-74...</td>\n",
+              "      <td>{'$agent_memory': {'extraction_id': 'escalatio...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>fact</td>\n",
+              "      <td>A follow-up commitment to provide a status upd...</td>\n",
+              "      <td>{'$agent_memory': {'extraction_id': 'follow_up...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  record_type                                            content  \\\n",
+              "0        fact  Replacement shipment RMA-8842 for order ORD-74...   \n",
+              "1        fact  A follow-up commitment to provide a status upd...   \n",
+              "\n",
+              "                                            metadata  \n",
+              "0  {'$agent_memory': {'extraction_id': 'escalatio...  \n",
+              "1  {'$agent_memory': {'extraction_id': 'follow_up...  "
+            ]
+          },
+          "execution_count": 19,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "escalation_results = list_extracted_records(custom_store, escalation_thread.thread_id)\n",
+        "\n",
+        "pd.DataFrame(\n",
+        "    escalation_results,\n",
+        "    columns=[\"record_type\", \"content\", \"metadata\"],\n",
+        ")[[\"record_type\", \"content\", \"metadata\"]]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ddd53865",
+      "metadata": {},
+      "source": [
+        "## Update and Clear Thread-Level Instructions\n",
+        "\n",
+        "`update_thread()` persists runtime configuration changes. Passing a partial\n",
+        "`MemoryExtractionConfig` updates only the provided fields. Passing\n",
+        "`memory_extraction_custom_instructions=None` clears the stored override.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "id": "8dcf0d3a",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Thread-level extraction instructions updated and cleared: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "updated_escalation_thread = custom_memory.update_thread(\n",
+        "    escalation_thread.thread_id,\n",
+        "    memory_extraction_config=MemoryExtractionConfig(\n",
+        "        memory_extraction_custom_instructions=(\n",
+        "            \"Extract only shipment escalation commitments and customer-facing follow-up deadlines.\"\n",
+        "        )\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "cleared_escalation_thread = custom_memory.update_thread(\n",
+        "    escalation_thread.thread_id,\n",
+        "    memory_extraction_config=MemoryExtractionConfig(\n",
+        "        memory_extraction_custom_instructions=None\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "print(\"Thread-level extraction instructions updated and cleared: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ee20e1ce",
+      "metadata": {},
+      "source": [
+        "## Add Tool-Result Metadata to a Support Thread\n",
+        "\n",
+        "Richeek's feedback also called out tool usage extraction as a useful custom extraction scenario. In a real support agent, reliable operational facts often come from tools: order status, shipment status, return authorization, entitlement checks, or case-management systems.\n",
+        "\n",
+        "This section represents a tool result as an assistant message and attaches shared workflow metadata to the message batch. The custom extraction policy preserves the tool-confirmed business fact, while metadata inheritance adds tags such as `tool:order_status` to the extracted memory.\n",
+        "\n",
+        "That gives the application two useful controls later:\n",
+        "\n",
+        "- the memory text captures the durable support fact;\n",
+        "- the metadata records where the fact came from and how it should be scoped.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "id": "7ef5573b",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Tool-aware policy and metadata: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "TOOL_AWARE_EXTRACTION_INSTRUCTIONS = \"\"\"\n",
+        "Extract durable support facts from user, assistant, and tool-result messages.\n",
+        "When the conversation contains a tool-confirmed status, preserve the business fact\n",
+        "but do not copy raw payload wording unless it is needed for follow-up.\n",
+        "Keep exact order IDs, shipment status, escalation reason, and customer-facing commitment.\n",
+        "\"\"\".strip()\n",
+        "\n",
+        "tool_metadata = {\n",
+        "    \"tenant\": \"acme\",\n",
+        "    \"source\": \"support-copilot\",\n",
+        "    \"tags\": [\"support\", \"tool:order_status\", \"replacement\"],\n",
+        "}\n",
+        "\n",
+        "print(\"Tool-aware policy and metadata: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d2fbcbc0",
+      "metadata": {},
+      "source": [
+        "### Run a Tool-Aware Thread\n",
+        "\n",
+        "The metadata is shared across the message batch so the selected metadata keys can be inherited safely by\n",
+        "extracted memories.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "id": "936316f3",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Tool-aware extraction thread: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "tool_thread = custom_memory.create_thread(\n",
+        "    thread_id=f\"tool_support_{RUN_ID}\",\n",
+        "    user_id=USER_ID,\n",
+        "    agent_id=AGENT_ID,\n",
+        "    memory_extraction_config=MemoryExtractionConfig(\n",
+        "        memory_extraction_frequency=1,\n",
+        "        enable_context_summary=False,\n",
+        "        memory_extraction_custom_instructions=TOOL_AWARE_EXTRACTION_INSTRUCTIONS,\n",
+        "        memory_extraction_inherit_message_metadata=[\"tenant\", \"source\", \"tags\"],\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "await tool_thread.add_messages_async(\n",
+        "    [\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": \"Can you check the replacement status for order ORD-7421?\",\n",
+        "        },\n",
+        "        {\n",
+        "            \"role\": \"assistant\",\n",
+        "            \"content\": (\n",
+        "                \"Tool result from order_status: replacement shipment RMA-8842 for order \"\n",
+        "                \"ORD-7421 is delayed because the hinge part is backordered. Escalate if \"\n",
+        "                \"it does not ship by Friday.\"\n",
+        "            ),\n",
+        "        },\n",
+        "    ],\n",
+        "    metadata=tool_metadata,\n",
+        ")\n",
+        "await tool_thread.wait_for_memory_extraction_async()\n",
+        "\n",
+        "print(\"Tool-aware extraction thread: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0d384e3b",
+      "metadata": {},
+      "source": [
+        "## Inspect Tool-Aware Memories\n",
+        "\n",
+        "Before applying metadata filters, inspect the memories extracted from the tool-aware support thread.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "id": "1125035e",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>record_type</th>\n",
+              "      <th>content</th>\n",
+              "      <th>metadata</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>fact</td>\n",
+              "      <td>Replacement shipment RMA-8842 for order ORD-74...</td>\n",
+              "      <td>{'tenant': 'acme', 'source': 'support-copilot'...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>guideline</td>\n",
+              "      <td>Escalate the order status if the replacement s...</td>\n",
+              "      <td>{'tenant': 'acme', 'source': 'support-copilot'...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  record_type                                            content  \\\n",
+              "0        fact  Replacement shipment RMA-8842 for order ORD-74...   \n",
+              "1   guideline  Escalate the order status if the replacement s...   \n",
+              "\n",
+              "                                            metadata  \n",
+              "0  {'tenant': 'acme', 'source': 'support-copilot'...  \n",
+              "1  {'tenant': 'acme', 'source': 'support-copilot'...  "
+            ]
+          },
+          "execution_count": 23,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "tool_stored_rows = list_extracted_records(custom_store, tool_thread.thread_id)\n",
+        "\n",
+        "pd.DataFrame(\n",
+        "    tool_stored_rows,\n",
+        "    columns=[\"record_type\", \"content\", \"metadata\"],\n",
+        ")[[\"record_type\", \"content\", \"metadata\"]]\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "5e648687",
+      "metadata": {},
+      "source": [
+        "## Search Extracted Memories by Tool Metadata\n",
+        "\n",
+        "After tool-aware extraction, metadata filters let the application retrieve memories that belong to a selected support workflow. This is the governance side of custom extraction: the memory can be useful while still being scoped by tenant, source, and tool tag.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "id": "6fdafa47",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tool_filtered_results = await tool_thread.search_async(\n",
+        "    \"replacement shipment delayed backordered hinge escalate\",\n",
+        "    max_results=5,\n",
+        "    exact_thread_match=True,\n",
+        "    record_types=[\"memory\", \"fact\", \"preference\", \"guideline\"],\n",
+        "    metadata_filter={\n",
+        "        \"tenant\": \"acme\",\n",
+        "        \"source\": \"support-copilot\",\n",
+        "        \"tags\": [\"support\", \"tool:order_status\", \"replacement\"],\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "tool_filtered_rows = [\n",
+        "    {\n",
+        "        \"record_type\": result.record.record_type,\n",
+        "        \"content\": result.content,\n",
+        "        \"metadata\": result.record.metadata,\n",
+        "    }\n",
+        "    for result in tool_filtered_results\n",
+        "]\n",
+        "\n",
+        "if tool_filtered_rows:\n",
+        "    pd.DataFrame(tool_filtered_rows)\n",
+        "else:\n",
+        "    pd.DataFrame(\n",
+        "        [{\"status\": \"No matching memories found. Re-run the tool-aware extraction cell before searching.\"}]\n",
+        "    )\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f04eba3c",
+      "metadata": {},
+      "source": [
+        "### Array Membership Filter Variant\n",
+        "\n",
+        "When metadata values are arrays, exact list matching is usually too strict. Array operators\n",
+        "such as `$array_contains`, `$array_contains_any`, and `$not` express workflow filters more\n",
+        "directly.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "id": "ab36cb54",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tool_membership_results = await tool_thread.search_async(\n",
+        "    \"order replacement status\",\n",
+        "    max_results=5,\n",
+        "    exact_thread_match=True,\n",
+        "    record_types=[\"memory\", \"fact\", \"preference\", \"guideline\"],\n",
+        "    metadata_filter={\n",
+        "        \"tenant\": \"acme\",\n",
+        "        \"tags\": {\n",
+        "            \"$array_contains\": \"tool:order_status\",\n",
+        "            \"$array_contains_any\": [\"replacement\", \"support\"],\n",
+        "            \"$not\": {\"$array_contains\": \"returns\"},\n",
+        "        },\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "membership_rows = [\n",
+        "    {\n",
+        "        \"record_type\": result.record.record_type,\n",
+        "        \"content\": result.content,\n",
+        "        \"metadata\": result.record.metadata,\n",
+        "    }\n",
+        "    for result in tool_membership_results\n",
+        "]\n",
+        "\n",
+        "if membership_rows:\n",
+        "    pd.DataFrame(membership_rows)\n",
+        "else:\n",
+        "    pd.DataFrame(\n",
+        "        [{\"status\": \"No matching memories found for the array membership filter.\"}]\n",
+        "    )\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ee9509ef",
+      "metadata": {},
+      "source": [
+        "# Part 5 - Production Notes and Cleanup\n",
+        "\n",
+        "The workflow is intentionally small, but the same patterns map to production. In enterprise agents, memory extraction should reflect workflow priorities, privacy boundaries, and domain-specific facts instead of summarizing everything the user said.\n",
+        "\n",
+        "This matters because better memory policy can lead to:\n",
+        "\n",
+        "- fewer noisy memories;\n",
+        "- more consistent agent behavior across sessions;\n",
+        "- better retrieval because durable facts are easier to search and scope;\n",
+        "- stronger compliance posture because sensitive or temporary details are less likely to become durable memory;\n",
+        "- clearer ownership of what the application considers useful memory.\n",
+        "\n",
+        "Operationally, production applications should also:\n",
+        "\n",
+        "- keep authentication and authorization in the surrounding application;\n",
+        "- scope every memory operation by user, agent, thread, and metadata;\n",
+        "- treat custom extraction as policy guidance, not a hard redaction guarantee;\n",
+        "- avoid sending secrets or unnecessary sensitive content into memory ingestion;\n",
+        "- monitor extraction failures and queue pressure when using background extraction;\n",
+        "- use TTL and delete APIs for lifecycle control;\n",
+        "- configure scheduler-job privileges when administrators want expired records to be physically purged automatically.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8f18ee19",
+      "metadata": {},
+      "source": [
+        "## Cleanup and Shutdown\n",
+        "\n",
+        "The cleanup step removes the run-scoped example user and then closes application-owned resources.\n",
+        "\n",
+        "The order matters:\n",
+        "\n",
+        "1. delete the example memory records created by this run;\n",
+        "2. close the Oracle AI Agent Memory clients so no more memory operations use the pool;\n",
+        "3. close the Oracle Database pool last.\n",
+        "\n",
+        "Keeping this at the end makes repeated notebook runs easier and avoids leaving unnecessary example data in shared development schemas.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "id": "ab4fa6e4",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cleanup and shutdown: READY\n"
+          ]
+        }
+      ],
+      "source": [
+        "cleanup_notes = []\n",
+        "\n",
+        "if \"custom_memory\" in globals():\n",
+        "    try:\n",
+        "        custom_memory.delete_user(USER_ID, cascade=True)\n",
+        "        cleanup_notes.append(\"example records removed\")\n",
+        "    except Exception:\n",
+        "        cleanup_notes.append(\"example record cleanup skipped\")\n",
+        "\n",
+        "for client_name in [\"base_memory\", \"custom_memory\"]:\n",
+        "    client = globals().get(client_name)\n",
+        "    if client is not None:\n",
+        "        try:\n",
+        "            client.close()\n",
+        "        except Exception:\n",
+        "            pass\n",
+        "\n",
+        "if \"db_pool\" in globals():\n",
+        "    try:\n",
+        "        db_pool.close(force=True)\n",
+        "        cleanup_notes.append(\"database pool closed\")\n",
+        "    except Exception:\n",
+        "        cleanup_notes.append(\"database pool close skipped\")\n",
+        "\n",
+        "print(\"Cleanup and shutdown: READY\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "28d3856c",
+      "metadata": {},
+      "source": [
+        "## What This Notebook Shows\n",
+        "\n",
+        "This notebook demonstrates how Oracle AI Agent Memory can make extraction policy explicit for a concrete customer support use case:\n",
+        "\n",
+        "1. **FreeSQL-ready setup:** the notebook connects to a FreeSQL Oracle Database schema and verifies basic table permissions before using Oracle AI Agent Memory.\n",
+        "2. **Domain-specific extraction:** custom instructions guide memory formation for order IDs, return requests, replacement context, delivery preferences, escalation commitments, and tool-confirmed facts.\n",
+        "3. **Baseline vs custom behavior:** the same conversation is processed through both paths so the stored memories can be compared directly.\n",
+        "4. **Thread-level control:** one support workflow can override, update, or clear extraction behavior without changing the global client policy.\n",
+        "5. **Tool-aware memory:** tool-result metadata can flow into memories and support scoped retrieval later.\n",
+        "6. **Governed retrieval:** metadata filters complement relevance so applications can constrain memory by tenant, source, tag, and workflow.\n",
+        "\n",
+        "For production, keep authentication and authorization in the surrounding application, avoid storing secrets, size database pools for concurrent extraction and retrieval, and use TTL/delete APIs for lifecycle control.\n",
+        "\n",
+        "## Resources\n",
+        "\n",
+        "- [Oracle AI Agent Memory package](https://pypi.org/project/oracleagentmemory/26.6.0/)\n",
+        "- [Oracle AI Agent Memory documentation](https://docs.oracle.com/en/database/oracle/agent-memory/26.4/)\n",
+        "- [FreeSQL](https://freesql.com/)\n",
+        "- [Oracle AI Vector Search documentation](https://docs.oracle.com/en/database/oracle/oracle-database/26/vecse/overview-ai-vector-search.html)\n"
+      ]
     }
-   ],
-   "source": [
-    "cleanup_notes = []\n",
-    "\n",
-    "if \"custom_memory\" in globals():\n",
-    "    try:\n",
-    "        custom_memory.delete_user(USER_ID, cascade=True)\n",
-    "        cleanup_notes.append(\"example records removed\")\n",
-    "    except Exception:\n",
-    "        cleanup_notes.append(\"example record cleanup skipped\")\n",
-    "\n",
-    "for client_name in [\"base_memory\", \"custom_memory\"]:\n",
-    "    client = globals().get(client_name)\n",
-    "    if client is not None:\n",
-    "        try:\n",
-    "            client.close()\n",
-    "        except Exception:\n",
-    "            pass\n",
-    "\n",
-    "if \"db_pool\" in globals():\n",
-    "    try:\n",
-    "        db_pool.close(force=True)\n",
-    "        cleanup_notes.append(\"database pool closed\")\n",
-    "    except Exception:\n",
-    "        cleanup_notes.append(\"database pool close skipped\")\n",
-    "\n",
-    "print(\"Cleanup and shutdown: READY\")\n"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv (3.11.6.final.0)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.6"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "28d3856c",
-   "metadata": {},
-   "source": [
-    "## What This Notebook Shows\n",
-    "\n",
-    "This notebook demonstrates how Oracle AI Agent Memory can make extraction policy explicit for a concrete customer support use case:\n",
-    "\n",
-    "1. **FreeSQL-ready setup:** the notebook connects to a FreeSQL Oracle Database schema and verifies basic table permissions before using Oracle AI Agent Memory.\n",
-    "2. **Domain-specific extraction:** custom instructions guide memory formation for order IDs, return requests, replacement context, delivery preferences, escalation commitments, and tool-confirmed facts.\n",
-    "3. **Baseline vs custom behavior:** the same conversation is processed through both paths so the stored memories can be compared directly.\n",
-    "4. **Thread-level control:** one support workflow can override, update, or clear extraction behavior without changing the global client policy.\n",
-    "5. **Tool-aware memory:** tool-result metadata can flow into memories and support scoped retrieval later.\n",
-    "6. **Governed retrieval:** metadata filters complement relevance so applications can constrain memory by tenant, source, tag, and workflow.\n",
-    "\n",
-    "For production, keep authentication and authorization in the surrounding application, avoid storing secrets, size database pools for concurrent extraction and retrieval, and use TTL/delete APIs for lifecycle control.\n",
-    "\n",
-    "## Resources\n",
-    "\n",
-    "- [Oracle AI Agent Memory package](https://pypi.org/project/oracleagentmemory/26.6.0/)\n",
-    "- [Oracle AI Agent Memory documentation](https://docs.oracle.com/en/database/oracle/agent-memory/26.4/)\n",
-    "- [FreeSQL](https://freesql.com/)\n",
-    "- [Oracle AI Vector Search documentation](https://docs.oracle.com/en/database/oracle/oracle-database/26/vecse/overview-ai-vector-search.html)\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv (3.11.6.final.0)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.6"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Add a FreeSQL connection guide to the custom memory extraction notebook.
- Show developers where to find the FreeSQL Python connection details and how to set the required `.env` values.
- Keep the notebook workflow unchanged.

## Validation
- Verified the notebook renders as valid JSON.
- Confirmed this change only adds guidance content.